### PR TITLE
migrate to zig 0.16

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,7 +63,7 @@ body:
     attributes:
       label: Zig Version
       description: What Zig version are you using?
-      placeholder: e.g., 0.15.0
+      placeholder: e.g., 0.16.0
     validations:
       required: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Run Zig tests
         run: zig build test --summary all
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Install QEMU and Multilib (Linux)
         if: runner.os == 'Linux' && (matrix.target == 'aarch64-linux' || matrix.target == 'x86-linux')
@@ -124,7 +124,7 @@ jobs:
       - name: Setup Zig
         uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Build for ${{ matrix.target }} (build-only)
         run: zig build -Dtarget=${{ matrix.target }} -Doptimize=Debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
       - name: Run Tests
         run: zig build test
 
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
       - name: Run Benchmarks
         id: run_bench
         run: |
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
       
       - name: Build Library
         run: zig build -Doptimize=ReleaseSafe -Dtarget=${{ matrix.target }}
@@ -109,7 +109,7 @@ jobs:
 
       - uses: mlugg/setup-zig@v2
         with:
-          version: 0.15.2
+          version: 0.16.0
 
       - name: Calculate Hash
         id: calc_hash

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 zig-cache/
 zig-out/
 .zig-cache/
+zig-pkg/
 
 # Log files
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Note:** Documentation for versions below 0.1.2 is not available. Please refer to commit history or pull requests for those versions.
 
+## [0.1.8] - Zig 0.16.0 Compatibility
+
+### Changed
+
+- Migrated the project to Zig 0.16.0 and updated package metadata to require `minimum_zig_version = "0.16.0"`.
+- Updated the public package version to `0.1.8`.
+- Migrated standard library I/O usage to the Zig 0.16 `std.Io` APIs across file, network, terminal, stream, and writer paths.
+- Updated allocator examples and documentation to use Zig 0.16-compatible `std.heap.DebugAllocator`.
+
+### Fixed
+
+- Fixed build system compatibility with Zig 0.16 package/dependency handling.
+- Fixed examples that used removed or deprecated writer, filesystem, file-close, and stream APIs.
+- Fixed Windows terminal ANSI enablement to use the cross-platform `std.Io.File.enableAnsiEscapeCodes` API.
+- Fixed stack trace ownership so captured trace buffers are deinitialized safely under Zig 0.16.
+- Fixed thread synchronization calls for Zig 0.16 `std.Io` lock APIs.
+
+### Documentation
+
+- Updated README installation, build, test, and usage snippets for Zig 0.16.0.
+- Updated API and guide documentation for `std.Io.Reader`, `std.Io.Writer`, `std.Io.File`, `std.Io.Dir`, and `std.Io.net` usage.
+- Updated all documented example snippets to avoid Zig 0.15-era filesystem, networking, and writer APIs.
+
+### Validation
+
+- Verified `zig build`.
+- Verified `zig build test`.
+- Verified `zig build run-all-examples`.
+
 ## [0.1.7]
 
 ### Added
@@ -30,7 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Allocator Ergonomics Improvements**:
   - Added `Config.withArenaAllocator()` and `Config.withArena()` aliases for clearer arena configuration in production code.
   - Refactored logger initialization paths to reuse shared setup internals and improve consistency.
-  - Added explicit test coverage for `Logger` initialization with `GeneralPurposeAllocator`.
+  - Added explicit test coverage for `Logger` initialization with the general-purpose debug allocator.
   - Added allocator strategy example (`examples/allocator_strategies.zig`) and matching docs page (`docs/examples/allocator-strategies.md`).
 - **Metrics Observability Extensions**:
   - Added latency percentile helpers: `latencyPercentileNs(...)` and `latencyPercentileMs(...)`.
@@ -96,7 +125,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added formatter regression coverage for `Config.TimeFormat.default_alias` and strict numeric `unix_ms` JSON output.
 - Added logger tests for traceparent parsing/propagation helper methods and distributed logger child/module helpers.
 - Added sink tests for flush stats correctness, error behavior (`disable_sink` / `propagate`), and manual `flushNow()` flow.
-- Added logger tests validating arena threshold reset behavior and `GeneralPurposeAllocator` compatibility.
+- Added logger tests validating arena threshold reset behavior and debug allocator compatibility.
 - Added regression tests for new metrics percentile/summary helpers and sink aggregate helpers.
 - Added regression tests for async in-flight stats and queue drain/utilization helpers.
 - Added regression tests for thread pool queue capacity/load helpers and timeout waits.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <img src="https://github.com/user-attachments/assets/565fc3dc-dd2c-47a6-bab6-2f545c551f26" alt="logly logo" width="400" />
 
 <a href="https://muhammad-fiaz.github.io/logly.zig/"><img src="https://img.shields.io/badge/docs-muhammad--fiaz.github.io-blue" alt="Documentation"></a>
-<a href="https://ziglang.org/"><img src="https://img.shields.io/badge/Zig-0.15.1-orange.svg?logo=zig" alt="Zig Version"></a>
+<a href="https://ziglang.org/"><img src="https://img.shields.io/badge/Zig-0.16.0-orange.svg?logo=zig" alt="Zig Version"></a>
 <a href="https://github.com/muhammad-fiaz/logly.zig"><img src="https://img.shields.io/github/stars/muhammad-fiaz/logly.zig" alt="GitHub stars"></a>
 <a href="https://github.com/muhammad-fiaz/logly.zig/issues"><img src="https://img.shields.io/github/issues/muhammad-fiaz/logly.zig" alt="GitHub issues"></a>
 <a href="https://github.com/muhammad-fiaz/logly.zig/pulls"><img src="https://img.shields.io/github/issues-pr/muhammad-fiaz/logly.zig" alt="GitHub pull requests"></a>
@@ -43,12 +43,11 @@ A production-grade, high-performance structured logging library for Zig, designe
 - [Supported Platforms](#supported-platforms)
   - [Color Support](#color-support)
 - [Recent Changes](#recent-changes)
-  - [Version 0.1.7](#version-017)
+    - [Version 0.1.8](#version-018)
 - [Installation](#installation)
   - [Method 1: Zig Fetch (Recommended Stable)](#method-1-zig-fetch-recommended-stable)
-  - [Method 2: Project Starter Template (Quick Start)](#method-2-project-starter-template-quick-start)
-  - [Method 3: Manual Configuration](#method-3-manual-configuration)
-  - [Method 4: Building from Source](#method-4-building-from-source)
+  - [Method 2: Manual Configuration](#method-2-manual-configuration)
+  - [Method 3: Building from Source](#method-3-building-from-source)
   - [Prebuilt Library](#prebuilt-library)
 - [Quick Start](#quick-start)
 - [Allocator Strategies (GPA + Arena)](#allocator-strategies-gpa--arena)
@@ -170,11 +169,13 @@ Before installing Logly, ensure you have the following:
 
 | Requirement | Version | Notes |
 |-------------|---------|-------|
-| **Zig** | 0.15.0+ | Download from [ziglang.org](https://ziglang.org/download/) |
+| **Zig** | 0.15.0+ or 0.16.0+ | Download from [ziglang.org](https://ziglang.org/download/) |
 | **Operating System** | Windows 10+, Linux, macOS | Cross-platform support |
 | **Terminal** | Any modern terminal | For colored output support |
 
 > Verify your Zig installation by running `zig version` in your terminal.
+> - For Zig 0.16.0+, use logly.zig version 0.1.8
+> - For Zig 0.15.0, use logly.zig version 0.1.7
 
 ---
 
@@ -207,7 +208,7 @@ Logly.Zig supports a wide range of platforms and architectures:
 
 ## Recent Changes
 
-### Version 0.1.7
+### Version 0.1.8
 
 **Highlights:**
 
@@ -241,61 +242,44 @@ For a complete version history, see [CHANGELOG.md](CHANGELOG.md).
 
 The easiest way to add Logly to your project:
 
-Latest stable (`0.1.7`):
+**For Zig 0.16.0+ (Latest stable `0.1.8`):**
+
+```bash
+zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz
+```
+
+**For Zig 0.15.0 (Use `0.1.7`):**
 
 ```bash
 zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.7.tar.gz
 ```
+
 This automatically adds the dependency with the correct hash to your `build.zig.zon`.
 
-Previous stable (`0.1.6`):
-
-```bash
-zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.6.tar.gz
-```
-This automatically adds the dependency with the correct hash to your `build.zig.zon`.
-
-or
-
-For Nightly builds, you can use the Git URL directly:
+**For Nightly builds:**
 
 ```bash
 zig fetch --save git+https://github.com/muhammad-fiaz/logly.zig.git
-
 ```
 
 This automatically adds the dependency with the correct hash to your `build.zig.zon`.
 
-### Method 2: Project Starter Template (Quick Start)
-
-Get started quickly with a pre-configured project template:
-
-**[Download Project Starter Example](https://download-directory.github.io/?url=https://github.com/muhammad-fiaz/logly.zig/tree/main/project-starter-example
-)**
-
-Or clone directly:
-```bash
-# Download and extract the starter template
-curl -L https://github.com/muhammad-fiaz/logly.zig/releases/latest/download/project-starter-example.zip -o logly-starter.zip
-unzip logly-starter.zip
-cd project-starter-example
-
-# Build and run
-zig build run
-```
-
-> [!NOTE]
-> **The starter template includes:**
-> - Pre-configured `build.zig` and `build.zig.zon`
-> - Example code demonstrating all major features
-> - Multiple sink configurations (console, file, rotation)
-> - Context binding and custom log levels
-> - JSON logging examples
-
-
-### Method 3: Manual Configuration
+### Method 2: Manual Configuration
 
 Add to your `build.zig.zon`:
+
+**For Zig 0.16.0+:**
+
+```zig
+.dependencies = .{
+    .logly = .{
+        .url = "https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz",
+        .hash = "...", // you needed to add hash here :)
+    },
+},
+```
+
+**For Zig 0.15.0:**
 
 ```zig
 .dependencies = .{
@@ -320,7 +304,7 @@ const logly = b.dependency("logly", .{
 exe.root_module.addImport("logly", logly.module("logly"));
 ```
 
-### Method 4: Building from Source
+### Method 3: Building from Source
 
 Clone the repository and build Logly:
 
@@ -357,7 +341,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -391,12 +375,12 @@ Default behavior:
 
 - Logger allocation strategy is the allocator you pass to `Logger.init(...)` / `Logger.initWithConfig(...)`.
 - `Config.use_arena_allocator` defaults to `false`.
-- The recommended default in applications is `std.heap.GeneralPurposeAllocator`.
+- The recommended default in applications is `std.heap.DebugAllocator`.
 
-Use `GeneralPurposeAllocator` as a production-safe default with leak tracking:
+Use `DebugAllocator` as a production-safe default with leak tracking:
 
 ```zig
-var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+var gpa = std.heap.DebugAllocator(.{}){};
 defer _ = gpa.deinit();
 
 const logger = try logly.Logger.init(gpa.allocator());
@@ -432,7 +416,7 @@ Field-vs-builder difference:
 - `config.use_arena_allocator = true` mutates your existing config variable.
 - `config = config.withArenaAllocator()` (or `withArenaAllocation()` / `withArena()`) returns a modified copy and requires reassignment.
 
-All examples in the `examples/` directory use `std.heap.GeneralPurposeAllocator` as the base allocator and then optionally enable logger arena scratch allocation per config.
+All examples in the `examples/` directory use `std.heap.DebugAllocator` as the base allocator and then optionally enable logger arena scratch allocation per config.
 
 When arena allocation is enabled, Logly automatically performs threshold-based arena resets between records to keep memory usage bounded while preserving high throughput.
 
@@ -639,7 +623,7 @@ Logly provides comprehensive OpenTelemetry support for distributed tracing, metr
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/bench/benchmark.zig
+++ b/bench/benchmark.zig
@@ -102,6 +102,7 @@ fn runBenchmark(
     notes: []const u8,
     category: []const u8,
 ) BenchmarkResult {
+    const io = logly.Utils.io();
     var min_latency: u64 = std.math.maxInt(u64);
     var max_latency: u64 = 0;
 
@@ -110,30 +111,18 @@ fn runBenchmark(
         benchFn(context) catch {};
     }
 
-    // Actual benchmark
-    var timer = std.time.Timer.start() catch return BenchmarkResult{
-        .name = name,
-        .iterations = 0,
-        .total_time_ns = 0,
-        .ops_per_sec = 0,
-        .avg_latency_ns = 0,
-        .min_latency_ns = 0,
-        .max_latency_ns = 0,
-        .notes = notes,
-        .category = category,
-    };
-
+    const timer_start = std.Io.Clock.awake.now(io);
     for (0..BENCHMARK_ITERATIONS) |_| {
-        const iter_start = timer.read();
+        const iter_start = std.Io.Clock.awake.now(io);
         benchFn(context) catch {};
-        const iter_end = timer.read();
+        const iter_end = std.Io.Clock.awake.now(io);
 
-        const latency = iter_end - iter_start;
+        const latency = @as(u64, @intCast(iter_end.nanoseconds - iter_start.nanoseconds));
         if (latency < min_latency) min_latency = latency;
         if (latency > max_latency) max_latency = latency;
     }
 
-    const total_time_ns = timer.read();
+    const total_time_ns = @as(u64, @intCast(std.Io.Clock.awake.now(io).nanoseconds - timer_start.nanoseconds));
     const ops_per_sec = @as(f64, @floatFromInt(BENCHMARK_ITERATIONS)) / (@as(f64, @floatFromInt(total_time_ns)) / 1_000_000_000.0);
     const avg_latency_ns = @as(f64, @floatFromInt(total_time_ns)) / @as(f64, @floatFromInt(BENCHMARK_ITERATIONS));
 
@@ -262,6 +251,7 @@ fn runMultiThreadBenchmark(
     allocator: std.mem.Allocator,
     comptime workerFn: fn (*const BenchContext) void,
 ) BenchmarkResult {
+    const io = logly.Utils.io();
     const ctx = BenchContext{ .logger = logger, .allocator = allocator };
 
     // Warmup
@@ -269,17 +259,7 @@ fn runMultiThreadBenchmark(
         logger.info("Warmup message", null) catch {};
     }
 
-    var timer = std.time.Timer.start() catch return BenchmarkResult{
-        .name = name,
-        .iterations = 0,
-        .total_time_ns = 0,
-        .ops_per_sec = 0,
-        .avg_latency_ns = 0,
-        .min_latency_ns = 0,
-        .max_latency_ns = 0,
-        .notes = notes,
-        .category = category,
-    };
+    const timer_start = std.Io.Clock.awake.now(io);
 
     // Spawn threads
     var threads: [16]?std.Thread = [_]?std.Thread{null} ** 16;
@@ -296,7 +276,7 @@ fn runMultiThreadBenchmark(
         }
     }
 
-    const total_time_ns = timer.read();
+    const total_time_ns = @as(u64, @intCast(std.Io.Clock.awake.now(io).nanoseconds - timer_start.nanoseconds));
     const total_ops = MT_BENCHMARK_ITERATIONS * actual_threads;
     const ops_per_sec = @as(f64, @floatFromInt(total_ops)) / (@as(f64, @floatFromInt(total_time_ns)) / 1_000_000_000.0);
     const avg_latency_ns = @as(f64, @floatFromInt(total_time_ns)) / @as(f64, @floatFromInt(total_ops));
@@ -315,7 +295,7 @@ fn runMultiThreadBenchmark(
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -1482,11 +1462,12 @@ pub fn main() !void {
     std.debug.print("[OK] Benchmarks completed successfully!\n\n", .{});
 
     // Write final Markdown report
-    const md_file = std.fs.cwd().createFile("benchmark-results.md", .{}) catch |err| {
+    const io = logly.Utils.io();
+    const md_file = std.Io.Dir.cwd().createFile(io, "benchmark-results.md", .{}) catch |err| {
         std.debug.print("Warning: Could not create benchmark-results.md: {}\n", .{err});
         return;
     };
-    defer md_file.close();
+    defer md_file.close(io);
 
     const md_header =
         \\#### 📊 LOGLY.ZIG BENCHMARK RESULTS
@@ -1509,7 +1490,7 @@ pub fn main() !void {
         BENCHMARK_ITERATIONS,
         MT_BENCHMARK_ITERATIONS,
     }) catch "";
-    try md_file.writeAll(header);
+    try md_file.writeStreamingAll(io, header);
 
     // Write categorized tables
     for (BenchmarkResult.categories) |cat| {
@@ -1532,7 +1513,7 @@ pub fn main() !void {
             \\
         , .{cat}) catch continue;
         defer allocator.free(cat_md);
-        try md_file.writeAll(cat_md);
+        try md_file.writeStreamingAll(io, cat_md);
 
         for (results.items) |r| {
             if (std.mem.eql(u8, r.category, cat)) {
@@ -1543,15 +1524,15 @@ pub fn main() !void {
                     r.avg_latency_ns,
                     r.notes,
                 }) catch continue;
-                try md_file.writeAll(line);
+                try md_file.writeStreamingAll(io, line);
             }
         }
-        try md_file.writeAll("</details>\n");
+        try md_file.writeStreamingAll(io, "</details>\n");
     }
 
     // Write summary to Markdown
     if (count > 0) {
-        try md_file.writeAll("\n### 📈 Benchmark Summary\n\n");
+        try md_file.writeStreamingAll(io, "\n### 📈 Benchmark Summary\n\n");
         var summary_buf: [1024]u8 = undefined;
         const summary = std.fmt.bufPrint(&summary_buf,
             \\- **Total benchmarks run:** {d}
@@ -1561,8 +1542,8 @@ pub fn main() !void {
             \\- **Average latency:** {d:.0} ns
             \\
         , .{ count, avg_ops, max_ops, max_name, min_ops, min_name, avg_latency }) catch "";
-        try md_file.writeAll(summary);
+        try md_file.writeStreamingAll(io, summary);
     }
 
-    try md_file.writeAll("\n---\n");
+    try md_file.writeStreamingAll(io, "\n---\n");
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .zstd = .{
-            .url = "git+https://github.com/muhammad-fiaz/zstd.zig.git#4f0fc73e52787d1dab0620412516e6ac9cc8f38c",
-            .hash = "zstd-1.6.0-biH4jAuQMgBpKrfhAYLEuSkWHj3a6qJwh1TtNIBpV_Hp",
+            .url = "git+https://github.com/muhammad-fiaz/zstd.zig.git#fde307fd8dd47cd90c1fb4524f04919d51913154",
+            .hash = "zstd-1.6.0-biH4jGjVMgBcWgNYfRHyn7Np8ttUWUU54a71UCPH5D32",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,8 +1,8 @@
 .{
     .name = .logly,
-    .version = "0.1.7",
+    .version = "0.1.8",
     .fingerprint = 0x54acba927bcb9891,
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .zstd = .{
             .url = "git+https://github.com/muhammad-fiaz/zstd.zig.git#4f0fc73e52787d1dab0620412516e6ac9cc8f38c",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -273,7 +273,7 @@ gtag('config', '${GA_ID}');`,
           priceCurrency: "USD",
         },
         downloadUrl: "https://github.com/muhammad-fiaz/logly.zig",
-        softwareVersion: "0.1.7",
+        softwareVersion: "0.1.8",
         license: "https://opensource.org/licenses/MIT",
       });
     } else {
@@ -359,10 +359,10 @@ gtag('config', '${GA_ID}');`,
         text: "Support",
         items: [
           {
-            text: "💖 Sponsor",
+            text: "ðŸ’– Sponsor",
             link: "https://github.com/sponsors/muhammad-fiaz",
           },
-          { text: "☕ Donate", link: "https://pay.muhammadfiaz.com" },
+          { text: "â˜• Donate", link: "https://pay.muhammadfiaz.com" },
         ],
       },
       { text: "GitHub", link: "https://github.com/muhammad-fiaz/logly.zig" },
@@ -512,7 +512,7 @@ gtag('config', '${GA_ID}');`,
 
     footer: {
       message: "Released under the MIT License.",
-      copyright: `Copyright © 2025-${new Date().getFullYear()} Muhammad Fiaz`,
+      copyright: `Copyright Â© 2025-${new Date().getFullYear()} Muhammad Fiaz`,
     },
 
     search: {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -359,11 +359,11 @@ gtag('config', '${GA_ID}');`,
         text: "Support",
         items: [
           {
-            text: "ðŸ’– Sponsor",
-            link: "https://github.com/sponsors/muhammad-fiaz",
+            text: "💖 Sponsor",
+                        link: "https://github.com/sponsors/muhammad-fiaz",
           },
-          { text: "â˜• Donate", link: "https://pay.muhammadfiaz.com" },
-        ],
+          { text: "☕ Donate", link: "https://pay.muhammadfiaz.com" },
+                ],
       },
       { text: "GitHub", link: "https://github.com/muhammad-fiaz/logly.zig" },
     ],
@@ -512,8 +512,8 @@ gtag('config', '${GA_ID}');`,
 
     footer: {
       message: "Released under the MIT License.",
-      copyright: `Copyright Â© 2025-${new Date().getFullYear()} Muhammad Fiaz`,
-    },
+      copyright: `Copyright © 2025-${new Date().getFullYear()} Muhammad Fiaz`,
+        },
 
     search: {
       provider: "local",

--- a/docs/api/async.md
+++ b/docs/api/async.md
@@ -550,7 +550,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/api/compression.md
+++ b/docs/api/compression.md
@@ -24,16 +24,16 @@ Comprehensive log file compression with multiple algorithms, streaming support, 
 | `decompress()` | `decode()`, `inflate()` | Decompress data |
 | `compressFile()` | `packFile()` | Compress a file |
 | `decompressFile()` | `unpackFile()` | Decompress a file |
-| `compressDirectory()` | `packDirectory()`, `archiveFolder()` | Compress directory (v0.1.5+) |
+| `compressDirectory()` | `packDirectory()`, `archiveFolder()` | Compress directory (v0.1.8+) |
 | `getStats()` | `statistics()` | Get compression statistics |
-| `resetStats()` | `clearStats()` | Reset statistics (v0.1.5+) |
-| `configure()` | `setConfig()`, `updateConfig()` | Update configuration (v0.1.5+) |
+| `resetStats()` | `clearStats()` | Reset statistics (v0.1.8+) |
+| `configure()` | `setConfig()`, `updateConfig()` | Update configuration (v0.1.8+) |
 | `shouldCompress()` | `needsCompression()` | Check if file needs compression |
-| `zstdCompression()` | `zstdDefault()` | Create zstd compressor (v0.1.5+) |
-| `zstdFast()` | `zstdSpeed()` | Create fast zstd compressor (v0.1.5+) |
-| `zstdBest()` | `zstdMax()` | Create best zstd compressor (v0.1.5+) |
+| `zstdCompression()` | `zstdDefault()` | Create zstd compressor (v0.1.8+) |
+| `zstdFast()` | `zstdSpeed()` | Create fast zstd compressor (v0.1.8+) |
+| `zstdBest()` | `zstdMax()` | Create best zstd compressor (v0.1.8+) |
 
-## Batch Compression Methods (v0.1.5+)
+## Batch Compression Methods (v0.1.8+)
 
 | Method | Description |
 |--------|-------------|
@@ -42,7 +42,7 @@ Comprehensive log file compression with multiple algorithms, streaming support, 
 | `compressOldest(dir, count)` | Compress N oldest files in directory |
 | `compressLargerThan(dir, size)` | Compress files larger than threshold |
 
-## Utility Methods (v0.1.5+)
+## Utility Methods (v0.1.8+)
 
 | Method | Description |
 |--------|-------------|
@@ -237,21 +237,21 @@ pub const CompressionAlgorithm = enum {
 };
 ```
 
-### Algorithm Comparison (v0.1.6+)
+### Algorithm Comparison (v0.1.8+)
 
 | Algorithm | Speed | Ratio | Best For |
 |-----------|-------|-------|----------|
-| `none` | ★★★★★ | - | Pass-through |
-| `deflate` | ★★★★ | ★★★ | General logs |
-| `zlib` | ★★★★ | ★★★ | HTTP/Web logs |
-| `gzip` | ★★★★ | ★★★ | File archives |
-| `zstd` | ★★★★★ | ★★★★ | High-perf logging |
-| `lzma` | ★★ | ★★★★★ | Long-term archival |
-| `lzma2` | ★★ | ★★★★★ | Large files |
-| `xz` | ★★ | ★★★★★ | Distribution |
-| `tar_gz` | ★★★ | ★★★★ | Multi-file archives |
-| `zip` | ★★★★ | ★★★ | Cross-platform |
-| `lz4` | ★★★★★ | ★★ | Real-time logging |
+| `none` | â˜…â˜…â˜…â˜…â˜… | - | Pass-through |
+| `deflate` | â˜…â˜…â˜…â˜… | â˜…â˜…â˜… | General logs |
+| `zlib` | â˜…â˜…â˜…â˜… | â˜…â˜…â˜… | HTTP/Web logs |
+| `gzip` | â˜…â˜…â˜…â˜… | â˜…â˜…â˜… | File archives |
+| `zstd` | â˜…â˜…â˜…â˜…â˜… | â˜…â˜…â˜…â˜… | High-perf logging |
+| `lzma` | â˜…â˜… | â˜…â˜…â˜…â˜…â˜… | Long-term archival |
+| `lzma2` | â˜…â˜… | â˜…â˜…â˜…â˜…â˜… | Large files |
+| `xz` | â˜…â˜… | â˜…â˜…â˜…â˜…â˜… | Distribution |
+| `tar_gz` | â˜…â˜…â˜… | â˜…â˜…â˜…â˜… | Multi-file archives |
+| `zip` | â˜…â˜…â˜…â˜… | â˜…â˜…â˜… | Cross-platform |
+| `lz4` | â˜…â˜…â˜…â˜…â˜… | â˜…â˜… | Real-time logging |
 
 ## CompressionConfig Preset Methods
 
@@ -293,7 +293,7 @@ The `CompressionConfig` struct provides preset factory methods for minimal confi
 | `production()` | Production-ready (balanced, background, checksums) |
 | `development()` | Development mode (fast, keep originals) |
 
-### Zstd Presets (v0.1.5+)
+### Zstd Presets (v0.1.8+)
 
 Zstandard (zstd) compression provides excellent compression ratios with very fast decompression. It's particularly well-suited for log files and streaming scenarios.
 
@@ -308,7 +308,7 @@ Zstandard (zstd) compression provides excellent compression ratios with very fas
 | `zstdProduction()` | Production zstd with background processing |
 | `zstdWithLevel(level)` | Custom zstd level (1-22) |
 
-### Custom Zstd Levels (v0.1.5+)
+### Custom Zstd Levels (v0.1.8+)
 
 Zstd supports compression levels from 1 to 22. Higher levels provide better compression but slower speed.
 
@@ -425,10 +425,10 @@ The `Config` struct provides quick-enable methods for compression:
 | `withBackgroundCompression()` | Background thread |
 | `withLogCompression()` | Log-optimized |
 | `withProductionCompression()` | Production-ready |
-| `withZstdCompression()` | Default zstd compression (v0.1.5+) |
-| `withZstdFastCompression()` | Fast zstd compression (v0.1.5+) |
-| `withZstdBestCompression()` | Best zstd compression (v0.1.5+) |
-| `withZstdProductionCompression()` | Production zstd (v0.1.5+) |
+| `withZstdCompression()` | Default zstd compression (v0.1.8+) |
+| `withZstdFastCompression()` | Fast zstd compression (v0.1.8+) |
+| `withZstdBestCompression()` | Best zstd compression (v0.1.8+) |
+| `withZstdProductionCompression()` | Production zstd (v0.1.8+) |
 
 **Usage Examples:**
 
@@ -439,7 +439,7 @@ var config = logly.Config.default().withCompressionEnabled();
 // Production-ready in one line
 var config2 = logly.Config.default().withProductionCompression();
 
-// Zstd compression with one line (v0.1.5+)
+// Zstd compression with one line (v0.1.8+)
 var config3 = logly.Config.default().withZstdCompression();
 
 // Chain with other settings
@@ -471,10 +471,10 @@ The `Compression` struct provides preset factory methods for direct instantiatio
 | `development(allocator)` | Development mode |
 | `background(allocator)` | Background thread |
 | `streaming(allocator)` | Streaming mode |
-| `zstdCompression(allocator)` | Default zstd (v0.1.5+) |
-| `zstdFast(allocator)` | Fast zstd (v0.1.5+) |
-| `zstdBest(allocator)` | Best zstd (v0.1.5+) |
-| `zstdProduction(allocator)` | Production zstd (v0.1.5+) |
+| `zstdCompression(allocator)` | Default zstd (v0.1.8+) |
+| `zstdFast(allocator)` | Fast zstd (v0.1.8+) |
+| `zstdBest(allocator)` | Best zstd (v0.1.8+) |
+| `zstdProduction(allocator)` | Production zstd (v0.1.8+) |
 
 **Usage Examples:**
 
@@ -485,7 +485,7 @@ defer compressor.deinit();
 
 try compressor.compressFile("logs/app.log", null);
 
-// Zstd compression instance (v0.1.5+)
+// Zstd compression instance (v0.1.8+)
 var zstd_compressor = logly.Compression.zstdCompression(allocator);
 defer zstd_compressor.deinit();
 
@@ -502,7 +502,7 @@ try zstd_compressor.compressFile("logs/app.log", null);
 | `zlib` | 3-5x | ~180 MB/s | ~280 MB/s | Network transport |
 | `raw_deflate` | 3-5x | ~220 MB/s | ~320 MB/s | Custom headers |
 | `gzip` | 3-5x | ~190 MB/s | ~290 MB/s | Standard file compatibility |
-| `zstd` | 3-6x | ~400 MB/s | ~1400 MB/s | High-performance, streaming (v0.1.5+) |
+| `zstd` | 3-6x | ~400 MB/s | ~1400 MB/s | High-performance, streaming (v0.1.8+) |
 
 
 ### CompressionLevel
@@ -872,7 +872,7 @@ const count = try compression.compressDirectory("logs/");
 std.debug.print("Compressed {d} files\n", .{count});
 ```
 
-### compressBatch (v0.1.5+)
+### compressBatch (v0.1.8+)
 
 Compresses multiple files in a batch operation.
 
@@ -893,7 +893,7 @@ const count = compression.compressBatch(files);
 std.debug.print("Compressed {d} files\n", .{count});
 ```
 
-### compressPattern (v0.1.5+)
+### compressPattern (v0.1.8+)
 
 Compresses files matching a glob pattern in a directory.
 
@@ -916,7 +916,7 @@ std.debug.print("Compressed {d} log files\n", .{count});
 const json_count = try compression.compressPattern("data/", "*.json");
 ```
 
-### compressOldest (v0.1.5+)
+### compressOldest (v0.1.8+)
 
 Compresses the N oldest files in a directory based on modification time.
 
@@ -936,7 +936,7 @@ const count = try compression.compressOldest("logs/", 5);
 std.debug.print("Compressed {d} oldest files\n", .{count});
 ```
 
-### compressLargerThan (v0.1.5+)
+### compressLargerThan (v0.1.8+)
 
 Compresses files larger than a specified size threshold.
 
@@ -954,7 +954,7 @@ std.debug.print("Compressed {d} large files\n", .{count});
 const large_count = try compression.compressLargerThan("logs/", 10 * 1024 * 1024);
 ```
 
-## Utility Methods (v0.1.5+)
+## Utility Methods (v0.1.8+)
 
 ### estimateCompressedSize
 
@@ -1026,17 +1026,18 @@ pub fn compressStream(self: *Compression, reader: anytype, writer: anytype) !voi
 
 **Features:**
 - Low memory footprint (no large buffers)
-- Compatible with `std.io.Reader` and `std.io.Writer`
+- Compatible with `std.Io.Reader` and `std.Io.Writer`
 - Supports GZIP and Deflate algorithms
 
 **Example:**
 
 ```zig
-var input_stream = std.io.fixedBufferStream(data);
-var output_buffer = std.ArrayList(u8).init(allocator);
-defer output_buffer.deinit();
+var input_stream = std.Io.Reader.fixed(data);
+var output_buffer: std.ArrayList(u8) = .empty;
+defer output_buffer.deinit(allocator);
 
-try compression.compressStream(input_stream.reader(), output_buffer.writer(allocator));
+var output_writer = logly.Utils.ArrayListWriter.init(&output_buffer, allocator);
+try compression.compressStream(&input_stream, &output_writer.writer);
 ```
 
 ### decompressStream
@@ -1050,11 +1051,12 @@ pub fn decompressStream(self: *Compression, reader: anytype, writer: anytype) !v
 **Example:**
 
 ```zig
-var input_stream = std.io.fixedBufferStream(compressed_data);
-var output_buffer = std.ArrayList(u8).init(allocator);
-defer output_buffer.deinit();
+var input_stream = std.Io.Reader.fixed(compressed_data);
+var output_buffer: std.ArrayList(u8) = .empty;
+defer output_buffer.deinit(allocator);
 
-try compression.decompressStream(input_stream.reader(), output_buffer.writer(allocator));
+var output_writer = logly.Utils.ArrayListWriter.init(&output_buffer, allocator);
+try compression.decompressStream(&input_stream, &output_writer.writer);
 ```
 
 ### shouldCompress
@@ -1242,9 +1244,9 @@ const size_config = CompressionPresets.onSize(50); // 50MB threshold
 
 ### Thread Safety
 
-- ✅ Thread-safe: All public methods protected by mutex
-- ✅ Atomic statistics: Lock-free reads
-- ⚠️ Callbacks: Must be thread-safe (called under lock)
+- âœ… Thread-safe: All public methods protected by mutex
+- âœ… Atomic statistics: Lock-free reads
+- âš ï¸ Callbacks: Must be thread-safe (called under lock)
 
 ### Performance Tips
 
@@ -1312,7 +1314,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -1335,7 +1337,7 @@ pub fn main() !void {
     defer if (result.output_path) |p| allocator.free(p);
 
     if (result.success) {
-        std.debug.print("✓ Compressed: {d:.1}% savings\\n", .{result.ratio() * 100});
+        std.debug.print("âœ“ Compressed: {d:.1}% savings\\n", .{result.ratio() * 100});
         
         // Get statistics
         const stats = compression.getStats();

--- a/docs/api/compression.md
+++ b/docs/api/compression.md
@@ -241,17 +241,17 @@ pub const CompressionAlgorithm = enum {
 
 | Algorithm | Speed | Ratio | Best For |
 |-----------|-------|-------|----------|
-| `none` | â˜…â˜…â˜…â˜…â˜… | - | Pass-through |
-| `deflate` | â˜…â˜…â˜…â˜… | â˜…â˜…â˜… | General logs |
-| `zlib` | â˜…â˜…â˜…â˜… | â˜…â˜…â˜… | HTTP/Web logs |
-| `gzip` | â˜…â˜…â˜…â˜… | â˜…â˜…â˜… | File archives |
-| `zstd` | â˜…â˜…â˜…â˜…â˜… | â˜…â˜…â˜…â˜… | High-perf logging |
-| `lzma` | â˜…â˜… | â˜…â˜…â˜…â˜…â˜… | Long-term archival |
-| `lzma2` | â˜…â˜… | â˜…â˜…â˜…â˜…â˜… | Large files |
-| `xz` | â˜…â˜… | â˜…â˜…â˜…â˜…â˜… | Distribution |
-| `tar_gz` | â˜…â˜…â˜… | â˜…â˜…â˜…â˜… | Multi-file archives |
-| `zip` | â˜…â˜…â˜…â˜… | â˜…â˜…â˜… | Cross-platform |
-| `lz4` | â˜…â˜…â˜…â˜…â˜… | â˜…â˜… | Real-time logging |
+| `none` | ★★★★★ | - | Pass-through |
+| `deflate` | ★★★★ | ★★★ | General logs |
+| `zlib` | ★★★★ | ★★★ | HTTP/Web logs |
+| `gzip` | ★★★★ | ★★★ | File archives |
+| `zstd` | ★★★★★ | ★★★★ | High-perf logging |
+| `lzma` | ★★ | ★★★★★ | Long-term archival |
+| `lzma2` | ★★ | ★★★★★ | Large files |
+| `xz` | ★★ | ★★★★★ | Distribution |
+| `tar_gz` | ★★★ | ★★★★ | Multi-file archives |
+| `zip` | ★★★★ | ★★★ | Cross-platform |
+| `lz4` | ★★★★★ | ★★ | Real-time logging |
 
 ## CompressionConfig Preset Methods
 

--- a/docs/api/compression.md
+++ b/docs/api/compression.md
@@ -1244,9 +1244,9 @@ const size_config = CompressionPresets.onSize(50); // 50MB threshold
 
 ### Thread Safety
 
-- âœ… Thread-safe: All public methods protected by mutex
-- âœ… Atomic statistics: Lock-free reads
-- âš ï¸ Callbacks: Must be thread-safe (called under lock)
+- ✅ Thread-safe: All public methods protected by mutex
+- ✅ Atomic statistics: Lock-free reads
+- ⚠️ Callbacks: Must be thread-safe (called under lock)
 
 ### Performance Tips
 
@@ -1337,8 +1337,8 @@ pub fn main() !void {
     defer if (result.output_path) |p| allocator.free(p);
 
     if (result.success) {
-        std.debug.print("âœ“ Compressed: {d:.1}% savings\\n", .{result.ratio() * 100});
-        
+        std.debug.print("✓ Compressed: {d:.1}% savings\\n", .{result.ratio() * 100});
+
         // Get statistics
         const stats = compression.getStats();
         std.debug.print("Total files: {d}\\n", 

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -93,7 +93,7 @@ You can also use your own application/request arena backed by GPA independently 
 ```zig
 const std = @import("std");
 
-var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+var gpa = std.heap.DebugAllocator(.{}){};
 defer _ = gpa.deinit();
 
 var request_arena = std.heap.ArenaAllocator.init(gpa.allocator());
@@ -149,25 +149,25 @@ Defaults for distributed headers are centralized in `Constants.ConfigDefaults` t
 OpenTelemetry integration configuration for trace and metric export. This section controls OTLP/Jaeger/Zipkin/Datadog/Azure/Google providers and local file exporters.
 
 Key fields:
-*   `enabled: bool` — Enable OpenTelemetry integration (default: `false`).
-*   `provider: Provider` — Provider enum (`.none`, `.jaeger`, `.zipkin`, `.datadog`, `.google_cloud`, `.google_analytics`, `.google_tag_manager`, `.aws_xray`, `.azure`, `.generic`, `.file`, `.custom`).
-*   `exporter_endpoint: ?[]const u8` — Exporter endpoint URL for HTTP/gRPC exporters (e.g., `"http://localhost:4317"`).
-*   `api_key: ?[]const u8` — API key for providers that require authentication.
-*   `connection_string: ?[]const u8` — Connection string for Azure Application Insights.
-*   `exporter_file_path: ?[]const u8` — File path for JSONL file exporter.
-*   `batch_size: usize = Constants.TelemetryDefaults.batch_size` — Batch span export size (default: 256).
-*   `batch_timeout_ms: u64 = Constants.TelemetryDefaults.batch_timeout_ms` — Batch export timeout in ms (default: 5000).
-*   `sampling_strategy: SamplingStrategy` — Sampling strategy (`.always_on`, `.always_off`, `.trace_id_ratio`, `.parent_based`).
-*   `sampling_rate: f64 = Constants.TelemetryDefaults.sampling_rate` — Sampling rate used when `trace_id_ratio` is selected.
-*   `service_name`, `service_version`, `environment`, `datacenter` — Resource identification fields.
-*   `span_processor_type: SpanProcessorType = .simple` — Span processor: `.simple` keeps completed spans pending until an explicit `exportSpans()` or `flush()` call; `.batch` will automatically export spans when the configured batch size or timeout is reached.
-*   `metric_format: MetricFormat` — Format for metrics export (e.g., `.otlp`, `.prometheus`, `.json`).
-*   `compress_exports: bool` — Whether to compress span export payloads.
-*   `custom_exporter_fn: ?*const fn () anyerror!void` — Optional custom exporter callback for user-defined exporters.
-*   `on_span_start`, `on_span_end`, `on_metric_recorded`, `on_error` — Lifecycle callbacks for telemetry events.
-*   `auto_context_propagation: bool` — Automatically propagate trace/context headers (default: `true`).
-*   `trace_header: []const u8 = Constants.TelemetryDefaults.trace_header` — Trace header name (default: `"traceparent"`).
-*   `baggage_header: []const u8 = Constants.TelemetryDefaults.baggage_header` — Baggage header name (default: `"baggage"`).
+*   `enabled: bool` â€” Enable OpenTelemetry integration (default: `false`).
+*   `provider: Provider` â€” Provider enum (`.none`, `.jaeger`, `.zipkin`, `.datadog`, `.google_cloud`, `.google_analytics`, `.google_tag_manager`, `.aws_xray`, `.azure`, `.generic`, `.file`, `.custom`).
+*   `exporter_endpoint: ?[]const u8` â€” Exporter endpoint URL for HTTP/gRPC exporters (e.g., `"http://localhost:4317"`).
+*   `api_key: ?[]const u8` â€” API key for providers that require authentication.
+*   `connection_string: ?[]const u8` â€” Connection string for Azure Application Insights.
+*   `exporter_file_path: ?[]const u8` â€” File path for JSONL file exporter.
+*   `batch_size: usize = Constants.TelemetryDefaults.batch_size` â€” Batch span export size (default: 256).
+*   `batch_timeout_ms: u64 = Constants.TelemetryDefaults.batch_timeout_ms` â€” Batch export timeout in ms (default: 5000).
+*   `sampling_strategy: SamplingStrategy` â€” Sampling strategy (`.always_on`, `.always_off`, `.trace_id_ratio`, `.parent_based`).
+*   `sampling_rate: f64 = Constants.TelemetryDefaults.sampling_rate` â€” Sampling rate used when `trace_id_ratio` is selected.
+*   `service_name`, `service_version`, `environment`, `datacenter` â€” Resource identification fields.
+*   `span_processor_type: SpanProcessorType = .simple` â€” Span processor: `.simple` keeps completed spans pending until an explicit `exportSpans()` or `flush()` call; `.batch` will automatically export spans when the configured batch size or timeout is reached.
+*   `metric_format: MetricFormat` â€” Format for metrics export (e.g., `.otlp`, `.prometheus`, `.json`).
+*   `compress_exports: bool` â€” Whether to compress span export payloads.
+*   `custom_exporter_fn: ?*const fn () anyerror!void` â€” Optional custom exporter callback for user-defined exporters.
+*   `on_span_start`, `on_span_end`, `on_metric_recorded`, `on_error` â€” Lifecycle callbacks for telemetry events.
+*   `auto_context_propagation: bool` â€” Automatically propagate trace/context headers (default: `true`).
+*   `trace_header: []const u8 = Constants.TelemetryDefaults.trace_header` â€” Trace header name (default: `"traceparent"`).
+*   `baggage_header: []const u8 = Constants.TelemetryDefaults.baggage_header` â€” Baggage header name (default: `"baggage"`).
 
 Presets and factory helpers:
 * `TelemetryConfig.jaeger()`, `TelemetryConfig.zipkin()`, `TelemetryConfig.datadog(api_key)`,
@@ -180,7 +180,7 @@ Presets and factory helpers:
 Notes:
 * Use `.simple` when you prefer explicit export control (call `exportSpans()` at safe points in your application). Use `.batch` for automatic behavior when you want the library to flush spans based on batch size or timeout.
 * Defaults are centralized in `Constants.TelemetryDefaults` (batch size, timeout, header defaults, etc.).
-* v0.1.6 includes a small OTLP exporter fix: a compile-time issue in the OTLP span writer (`writeOtlpSpan`) was resolved so the telemetry feature builds cleanly across targets.
+* v0.1.8 includes a small OTLP exporter fix: a compile-time issue in the OTLP span writer (`writeOtlpSpan`) was resolved so the telemetry feature builds cleanly across targets.
 
 
 ### Display Options
@@ -295,7 +295,7 @@ Custom format structure configuration.
 
 #### `level_colors: LevelColorConfig`
 
-Level-specific color customization with theme presets (v0.1.5).
+Level-specific color customization with theme presets (v0.1.8).
 - `theme_preset`: Theme preset for base colors (`.default`, `.bright`, `.dim`, `.minimal`, `.neon`, `.pastel`, `.dark`, `.light`, `.none`).
 - `trace_color`, `debug_color`, `info_color`, `notice_color`, `success_color`, `warning_color`, `error_color`, `fail_color`, `critical_color`, `fatal_color`: Individual color overrides (take precedence over theme).
 - `use_rgb`: Use RGB color mode.
@@ -444,7 +444,7 @@ Rules system configuration. The rules system **respects global switches** (`glob
 - `include_rule_id_prefix`: Include "R0001:" prefix. Default: `false`.
 - `rule_id_format`: Custom rule ID format. Default: `"R{d}"`.
 - `indent`: Message indent. Default: `"    "`.
-- `message_prefix`: Prefix character (deprecated, use `symbols`). Default: `"↳"`.
+- `message_prefix`: Prefix character (deprecated, use `symbols`). Default: `"â†³"`.
 - `symbols`: Custom symbols for message categories. See [RuleSymbols](#rulesymbols).
 - `console_output`: Output to console (AND'd with `global_console_display`). Default: `true`.
 - `file_output`: Output to files (AND'd with `global_file_storage`). Default: `true`.
@@ -616,7 +616,7 @@ Enables log-optimized compression (text strategy).
 
 Enables production-ready compression (balanced, checksums, background).
 
-### Zstd Compression Methods (v0.1.5+)
+### Zstd Compression Methods (v0.1.8+)
 
 ### `withZstdCompression() Config`
 

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -149,25 +149,25 @@ Defaults for distributed headers are centralized in `Constants.ConfigDefaults` t
 OpenTelemetry integration configuration for trace and metric export. This section controls OTLP/Jaeger/Zipkin/Datadog/Azure/Google providers and local file exporters.
 
 Key fields:
-*   `enabled: bool` â€” Enable OpenTelemetry integration (default: `false`).
-*   `provider: Provider` â€” Provider enum (`.none`, `.jaeger`, `.zipkin`, `.datadog`, `.google_cloud`, `.google_analytics`, `.google_tag_manager`, `.aws_xray`, `.azure`, `.generic`, `.file`, `.custom`).
-*   `exporter_endpoint: ?[]const u8` â€” Exporter endpoint URL for HTTP/gRPC exporters (e.g., `"http://localhost:4317"`).
-*   `api_key: ?[]const u8` â€” API key for providers that require authentication.
-*   `connection_string: ?[]const u8` â€” Connection string for Azure Application Insights.
-*   `exporter_file_path: ?[]const u8` â€” File path for JSONL file exporter.
-*   `batch_size: usize = Constants.TelemetryDefaults.batch_size` â€” Batch span export size (default: 256).
-*   `batch_timeout_ms: u64 = Constants.TelemetryDefaults.batch_timeout_ms` â€” Batch export timeout in ms (default: 5000).
-*   `sampling_strategy: SamplingStrategy` â€” Sampling strategy (`.always_on`, `.always_off`, `.trace_id_ratio`, `.parent_based`).
-*   `sampling_rate: f64 = Constants.TelemetryDefaults.sampling_rate` â€” Sampling rate used when `trace_id_ratio` is selected.
-*   `service_name`, `service_version`, `environment`, `datacenter` â€” Resource identification fields.
-*   `span_processor_type: SpanProcessorType = .simple` â€” Span processor: `.simple` keeps completed spans pending until an explicit `exportSpans()` or `flush()` call; `.batch` will automatically export spans when the configured batch size or timeout is reached.
-*   `metric_format: MetricFormat` â€” Format for metrics export (e.g., `.otlp`, `.prometheus`, `.json`).
-*   `compress_exports: bool` â€” Whether to compress span export payloads.
-*   `custom_exporter_fn: ?*const fn () anyerror!void` â€” Optional custom exporter callback for user-defined exporters.
-*   `on_span_start`, `on_span_end`, `on_metric_recorded`, `on_error` â€” Lifecycle callbacks for telemetry events.
-*   `auto_context_propagation: bool` â€” Automatically propagate trace/context headers (default: `true`).
-*   `trace_header: []const u8 = Constants.TelemetryDefaults.trace_header` â€” Trace header name (default: `"traceparent"`).
-*   `baggage_header: []const u8 = Constants.TelemetryDefaults.baggage_header` â€” Baggage header name (default: `"baggage"`).
+*   `enabled: bool` -  Enable OpenTelemetry integration (default: `false`).
+*   `provider: Provider` - Provider enum (`.none`, `.jaeger`, `.zipkin`, `.datadog`, `.google_cloud`, `.google_analytics`, `.google_tag_manager`, `.aws_xray`, `.azure`, `.generic`, `.file`, `.custom`).
+*   `exporter_endpoint: ?[]const u8` -  Exporter endpoint URL for HTTP/gRPC exporters (e.g., `"http://localhost:4317"`).
+*   `api_key: ?[]const u8` -  API key for providers that require authentication.
+*   `connection_string: ?[]const u8` -  Connection string for Azure Application Insights.
+*   `exporter_file_path: ?[]const u8` -  File path for JSONL file exporter.
+*   `batch_size: usize = Constants.TelemetryDefaults.batch_size` -  Batch span export size (default: 256).
+*   `batch_timeout_ms: u64 = Constants.TelemetryDefaults.batch_timeout_ms` -  Batch export timeout in ms (default: 5000).
+*   `sampling_strategy: SamplingStrategy` -  Sampling strategy (`.always_on`, `.always_off`, `.trace_id_ratio`, `.parent_based`).
+*   `sampling_rate: f64 = Constants.TelemetryDefaults.sampling_rate` -  Sampling rate used when `trace_id_ratio` is selected.
+*   `service_name`, `service_version`, `environment`, `datacenter` -  Resource identification fields.
+*   `span_processor_type: SpanProcessorType = .simple` -  Span processor: `.simple` keeps completed spans pending until an explicit `exportSpans()` or `flush()` call; `.batch` will automatically export spans when the configured batch size or timeout is reached.
+*   `metric_format: MetricFormat` -  Format for metrics export (e.g., `.otlp`, `.prometheus`, `.json`).
+*   `compress_exports: bool` -  Whether to compress span export payloads.
+*   `custom_exporter_fn: ?*const fn () anyerror!void` -  Optional custom exporter callback for user-defined exporters.
+*   `on_span_start`, `on_span_end`, `on_metric_recorded`, `on_error` -  Lifecycle callbacks for telemetry events.
+*   `auto_context_propagation: bool` -  Automatically propagate trace/context headers (default: `true`).
+*   `trace_header: []const u8 = Constants.TelemetryDefaults.trace_header` -  Trace header name (default: `"traceparent"`).
+*   `baggage_header: []const u8 = Constants.TelemetryDefaults.baggage_header` -  Baggage header name (default: `"baggage"`).
 
 Presets and factory helpers:
 * `TelemetryConfig.jaeger()`, `TelemetryConfig.zipkin()`, `TelemetryConfig.datadog(api_key)`,

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -444,7 +444,7 @@ Rules system configuration. The rules system **respects global switches** (`glob
 - `include_rule_id_prefix`: Include "R0001:" prefix. Default: `false`.
 - `rule_id_format`: Custom rule ID format. Default: `"R{d}"`.
 - `indent`: Message indent. Default: `"    "`.
-- `message_prefix`: Prefix character (deprecated, use `symbols`). Default: `"â†³"`.
+- `message_prefix`: Prefix character (deprecated, use `symbols`). Default: `"↳"`.
 - `symbols`: Custom symbols for message categories. See [RuleSymbols](#rulesymbols).
 - `console_output`: Output to console (AND'd with `global_console_display`). Default: `true`.
 - `file_output`: Output to files (AND'd with `global_file_storage`). Default: `true`.

--- a/docs/api/constants.md
+++ b/docs/api/constants.md
@@ -299,7 +299,7 @@ pub const RulesConstants = struct {
     /// Default indentation for rule messages
     pub const default_indent: []const u8 = "    ";
     /// Default prefix character for rule messages
-    pub const default_prefix: []const u8 = "â†³";
+    pub const default_prefix: []const u8 = "↳";
     /// Default prefix character for ASCII mode
     pub const default_prefix_ascii: []const u8 = "|--";
     /// Maximum number of rules allowed by default
@@ -309,17 +309,17 @@ pub const RulesConstants = struct {
 
     /// Unicode prefixes for each message category
     pub const Prefixes = struct {
-        pub const cause: []const u8 = "â¦¿ cause:";
-        pub const fix: []const u8 = "âœ¦ fix:";
-        pub const suggest: []const u8 = "â†’ suggest:";
-        pub const action: []const u8 = "â–¸ action:";
-        pub const docs: []const u8 = "ðŸ“– docs:";
-        pub const report: []const u8 = "ðŸ”— report:";
-        pub const note: []const u8 = "â„¹ note:";
-        pub const caution: []const u8 = "âš  caution:";
-        pub const perf: []const u8 = "âš¡ perf:";
-        pub const security: []const u8 = "ðŸ›¡ security:";
-        pub const custom: []const u8 = "â€¢";
+       pub const cause: []const u8 = "⦿ cause:";
+        pub const fix: []const u8 = "✦ fix:";
+        pub const suggest: []const u8 = "→ suggest:";
+        pub const action: []const u8 = "▸ action:";
+        pub const docs: []const u8 = "📖 docs:";
+        pub const report: []const u8 = "🔗 report:";
+        pub const note: []const u8 = "ℹ note:";
+        pub const caution: []const u8 = "⚠ caution:";
+        pub const perf: []const u8 = "⚡ perf:";
+        pub const security: []const u8 = "🛡 security:";
+        pub const custom: []const u8 = "•";
     };
 
     /// ASCII-only prefixes for each message category

--- a/docs/api/constants.md
+++ b/docs/api/constants.md
@@ -299,7 +299,7 @@ pub const RulesConstants = struct {
     /// Default indentation for rule messages
     pub const default_indent: []const u8 = "    ";
     /// Default prefix character for rule messages
-    pub const default_prefix: []const u8 = "↳";
+    pub const default_prefix: []const u8 = "â†³";
     /// Default prefix character for ASCII mode
     pub const default_prefix_ascii: []const u8 = "|--";
     /// Maximum number of rules allowed by default
@@ -309,17 +309,17 @@ pub const RulesConstants = struct {
 
     /// Unicode prefixes for each message category
     pub const Prefixes = struct {
-        pub const cause: []const u8 = "⦿ cause:";
-        pub const fix: []const u8 = "✦ fix:";
-        pub const suggest: []const u8 = "→ suggest:";
-        pub const action: []const u8 = "▸ action:";
-        pub const docs: []const u8 = "📖 docs:";
-        pub const report: []const u8 = "🔗 report:";
-        pub const note: []const u8 = "ℹ note:";
-        pub const caution: []const u8 = "⚠ caution:";
-        pub const perf: []const u8 = "⚡ perf:";
-        pub const security: []const u8 = "🛡 security:";
-        pub const custom: []const u8 = "•";
+        pub const cause: []const u8 = "â¦¿ cause:";
+        pub const fix: []const u8 = "âœ¦ fix:";
+        pub const suggest: []const u8 = "â†’ suggest:";
+        pub const action: []const u8 = "â–¸ action:";
+        pub const docs: []const u8 = "ðŸ“– docs:";
+        pub const report: []const u8 = "ðŸ”— report:";
+        pub const note: []const u8 = "â„¹ note:";
+        pub const caution: []const u8 = "âš  caution:";
+        pub const perf: []const u8 = "âš¡ perf:";
+        pub const security: []const u8 = "ðŸ›¡ security:";
+        pub const custom: []const u8 = "â€¢";
     };
 
     /// ASCII-only prefixes for each message category
@@ -614,7 +614,7 @@ pub const SinkDefaults = struct {
 };
 ```
 
-## Colors Constants (v0.1.5)
+## Colors Constants (v0.1.8)
 
 Comprehensive color system with ANSI codes, 256-color, and RGB support.
 

--- a/docs/api/customizations.md
+++ b/docs/api/customizations.md
@@ -80,7 +80,7 @@ Per-level ANSI color code customization with theme presets and individual overri
 
 **Type:** `Config.LevelColorConfig`
 
-### LevelColorConfig (v0.1.5)
+### LevelColorConfig (v0.1.8)
 
 ```zig
 pub const LevelColorConfig = struct {

--- a/docs/api/diagnostics.md
+++ b/docs/api/diagnostics.md
@@ -148,7 +148,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
     
@@ -329,7 +329,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/api/filter.md
+++ b/docs/api/filter.md
@@ -227,11 +227,11 @@ Explicitly deny a specific module.
 
 #### `allowRegex(regex: []const u8) !void`
  
- Allow messages matching a regex-like pattern. Uses the improved regex engine (v0.1.5).
+ Allow messages matching a regex-like pattern. Uses the improved regex engine (v0.1.8).
  
  #### `denyRegex(regex: []const u8) !void`
  
- Deny messages matching a regex-like pattern. Uses the improved regex engine (v0.1.5).
+ Deny messages matching a regex-like pattern. Uses the improved regex engine (v0.1.8).
 
 #### `addContextMatch(key: []const u8, pattern: []const u8, action: Action) !void`
 

--- a/docs/api/formatter.md
+++ b/docs/api/formatter.md
@@ -182,7 +182,7 @@ Statistics for formatter performance.
 | `throughputBytesPerSecond(elapsed_seconds)` | `f64` | Calculate throughput (bytes per second) |
 
 ::: tip Precise Byte Tracking
-As of v0.1.5, `total_bytes_formatted` captures the exact length of each formatted message, replacing previous estimations.
+As of v0.1.8, `total_bytes_formatted` captures the exact length of each formatted message, replacing previous estimations.
 :::
 
 #### Reset
@@ -233,13 +233,13 @@ The `Theme` struct defines custom ANSI color codes for each log level.
 | `trace` | `[]const u8` | `"36"` (Cyan) | Color for TRACE level |
 | `debug` | `[]const u8` | `"34"` (Blue) | Color for DEBUG level |
 | `info` | `[]const u8` | `"37"` (White) | Color for INFO level |
-| `notice` | `[]const u8` | `"96"` (Bright Cyan) | Color for NOTICE level (v0.1.5) |
+| `notice` | `[]const u8` | `"96"` (Bright Cyan) | Color for NOTICE level (v0.1.8) |
 | `success` | `[]const u8` | `"32"` (Green) | Color for SUCCESS level |
 | `warning` | `[]const u8` | `"33"` (Yellow) | Color for WARNING level |
 | `err` | `[]const u8` | `"31"` (Red) | Color for ERROR level |
 | `fail` | `[]const u8` | `"35"` (Magenta) | Color for FAIL level |
 | `critical` | `[]const u8` | `"91"` (Bright Red) | Color for CRITICAL level |
-| `fatal` | `[]const u8` | `"91;1"` (Bright Red Bold) | Color for FATAL level (v0.1.5) |
+| `fatal` | `[]const u8` | `"91;1"` (Bright Red Bold) | Color for FATAL level (v0.1.8) |
 
 ### Basic Usage
 
@@ -252,7 +252,7 @@ theme.err = "1;31"; // Change ERROR to Bold Red
 logger.sinks.items[0].formatter.setTheme(theme);
 ```
 
-### Theme Presets (v0.1.5)
+### Theme Presets (v0.1.8)
 
 ```zig
 const Theme = logly.Formatter.Theme;
@@ -261,7 +261,7 @@ const Theme = logly.Formatter.Theme;
 const default_theme = Theme{};              // Standard colors
 const bright = Theme.bright();              // Bold/bright colors
 const dim = Theme.dim();                    // Dim colors
-const underlined = Theme.underlined();      // Underlined colors (v0.1.5)
+const underlined = Theme.underlined();      // Underlined colors (v0.1.8)
 const minimal = Theme.minimal();            // Subtle grays
 const neon = Theme.neon();                  // Vivid 256-colors
 const pastel = Theme.pastel();              // Soft colors
@@ -287,7 +287,7 @@ formatter.setTheme(Theme.neon());
 | `dark()` | 38;5;37 | 38;5;33 | 38;5;245 | 38;5;34 | 38;5;214 | 38;5;160 | 38;5;196 |
 | `light()` | 38;5;30 | 38;5;27 | 38;5;238 | 38;5;28 | 38;5;172 | 38;5;124 | 38;5;160 |
 
-### Custom RGB Theme (v0.1.5)
+### Custom RGB Theme (v0.1.8)
 
 ```zig
 // Create a theme from RGB values
@@ -302,7 +302,7 @@ const custom = Theme.fromRgb(
 );
 ```
 
-## ColorStyle (v0.1.5)
+## ColorStyle (v0.1.8)
 
 The `ColorStyle` enum controls which color variant to use:
 

--- a/docs/api/level.md
+++ b/docs/api/level.md
@@ -131,7 +131,7 @@ const level = Level.fatal;
 const color = level.defaultColor(); // Returns "97;41" (white on red)
 ```
 
-### brightColor (v0.1.5)
+### brightColor (v0.1.8)
 
 Returns the bright/bold color variant. Uses `Constants.Colors.Themes.bright`.
 
@@ -140,7 +140,7 @@ const level = Level.trace;
 const bright = level.brightColor(); // Returns "96;1" (bright cyan bold)
 ```
 
-### dimColor (v0.1.5)
+### dimColor (v0.1.8)
 
 Returns the dim color variant. Uses `Constants.Colors.Themes.dim`.
 
@@ -149,7 +149,7 @@ const level = Level.info;
 const dim = level.dimColor(); // Returns "37;2" (white dim)
 ```
 
-### underlineColor (v0.1.5)
+### underlineColor (v0.1.8)
 
 Returns the underline color variant. Uses `Constants.Colors.Themes.underlined`.
 
@@ -158,7 +158,7 @@ const level = Level.warning;
 const underline = level.underlineColor(); // Returns "33;4" (yellow underline)
 ```
 
-### color256 (v0.1.5)
+### color256 (v0.1.8)
 
 Returns the 256-color palette code. Uses `Constants.Colors.Themes.neon`.
 
@@ -176,12 +176,12 @@ pub const CustomLevel = struct {
     name: []const u8,           // Display name (e.g., "AUDIT")
     priority: u8,               // Numeric priority
     color: []const u8,          // ANSI color code
-    bright_color: ?[]const u8,  // Bright color variant (v0.1.5)
-    dim_color: ?[]const u8,     // Dim color variant (v0.1.5)
-    color_256: ?[]const u8,     // 256-color code (v0.1.5)
-    rgb_color: ?struct { r: u8, g: u8, b: u8 },  // RGB color (v0.1.5)
-    bg_color: ?[]const u8,      // Background color (v0.1.5)
-    style: ?[]const u8,         // Text style (v0.1.5)
+    bright_color: ?[]const u8,  // Bright color variant (v0.1.8)
+    dim_color: ?[]const u8,     // Dim color variant (v0.1.8)
+    color_256: ?[]const u8,     // 256-color code (v0.1.8)
+    rgb_color: ?struct { r: u8, g: u8, b: u8 },  // RGB color (v0.1.8)
+    bg_color: ?[]const u8,      // Background color (v0.1.8)
+    style: ?[]const u8,         // Text style (v0.1.8)
 };
 ```
 
@@ -199,7 +199,7 @@ try logger.customf("AUDIT", "User {s} logged in", .{"admin"}, @src());
 logger.removeCustomLevel("AUDIT");
 ```
 
-### Advanced CustomLevel Constructors (v0.1.5)
+### Advanced CustomLevel Constructors (v0.1.8)
 
 ```zig
 const CustomLevel = logly.CustomLevel;
@@ -227,7 +227,7 @@ const styled = CustomLevel.initStyled("STYLED", 45, "31", "1;4");
 const alert = CustomLevel.initWithBackground("ALERT", 50, "97", "41");
 ```
 
-### CustomLevel Methods (v0.1.5)
+### CustomLevel Methods (v0.1.8)
 
 ```zig
 const custom = CustomLevel.initFull("TEST", 42, "32", "92;1", "32;2", "38;5;46");
@@ -275,7 +275,7 @@ if (level1.priority() < level2.priority()) {
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     const allocator = gpa.allocator();
 
     const logger = try logly.Logger.init(allocator);

--- a/docs/api/logger.md
+++ b/docs/api/logger.md
@@ -103,11 +103,11 @@ Initializes a new `Logger` instance with a specific configuration preset.
 
 `Logger.init(...)` and `Logger.initWithConfig(...)` accept any allocator implementing `std.mem.Allocator`.
 
-- Use `std.heap.GeneralPurposeAllocator` for robust general-purpose ownership and leak detection.
+- Use `std.heap.DebugAllocator` for robust general-purpose ownership and leak detection.
 - Enable arena scratch allocation with `Config.withArenaAllocation()` (aliases: `withArenaAllocator()`, `withArena()`) for high-throughput temporary allocations.
 
 ```zig
-var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+var gpa = std.heap.DebugAllocator(.{}){};
 defer _ = gpa.deinit();
 
 var config = logly.Config.production().withArenaAllocator();

--- a/docs/api/network.md
+++ b/docs/api/network.md
@@ -160,15 +160,15 @@ pub const NetworkError = error{
 
 ## Functions
 
-### `connectTcp(allocator: std.mem.Allocator, uri: []const u8) !std.net.Stream`
+### `connectTcp(allocator: std.mem.Allocator, uri: []const u8) !std.Io.net.Stream`
 
 Connects to a TCP host specified by a URI string (e.g., "tcp://127.0.0.1:8080").
 
-### `createUdpSocket(allocator: std.mem.Allocator, uri: []const u8) !struct { socket: std.posix.socket_t, address: std.net.Address }`
+### `createUdpSocket(allocator: std.mem.Allocator, uri: []const u8) !struct { socket: std.Io.net.Socket, address: std.Io.net.IpAddress }`
 
 Creates a UDP socket connected to a host specified by a URI string (e.g., "udp://127.0.0.1:514").
 
-### `sendUdp(socket: std.posix.socket_t, address: std.net.Address, data: []const u8) !void`
+### `sendUdp(socket: std.Io.net.Socket, address: std.Io.net.IpAddress, data: []const u8) !void`
 
 Sends data via UDP socket.
 
@@ -230,20 +230,21 @@ const udp_sink = logly.SinkConfig{
 ```zig
 const logly = @import("logly");
 const Network = logly.Network;
+const io = logly.Utils.io();
 
 // Connect to TCP server
 const stream = try Network.connectTcp(allocator, "tcp://localhost:8080");
-defer stream.close();
+defer stream.close(io);
 
 // Create UDP socket for Syslog
 const udp = try Network.createUdpSocket(allocator, "udp://localhost:514");
-defer std.posix.close(udp.socket);
+defer udp.socket.close(io);
 
 // Send UDP data
 try Network.sendUdp(udp.socket, udp.address, "Hello Syslog");
 
 // Fetch JSON from URL
-const json = try Network.fetchJson(allocator, "https://api.example.com/config", &.{}));
+const json = try Network.fetchJson(allocator, "https://api.example.com/config", &.{});
 defer json.deinit();
 
 // Format Syslog message

--- a/docs/api/record.md
+++ b/docs/api/record.md
@@ -160,9 +160,9 @@ pub const ErrorInfo = struct {
 Duration of the operation in nanoseconds. Useful for performance logging. Default: `null`.
 
 ```zig
-const start = std.time.nanoTimestamp();
+const start = logly.Utils.currentNanos();
 // ... operation ...
-record.duration_ns = @as(u64, @intCast(std.time.nanoTimestamp() - start));
+record.duration_ns = @as(u64, @intCast(logly.Utils.currentNanos() - start));
 ```
 
 ## Context

--- a/docs/api/rotation.md
+++ b/docs/api/rotation.md
@@ -224,11 +224,11 @@ try rot.applyConfig(global_config.rotation);
 
 ### Rotation Decision Helpers
 
-#### `getRotationReason(self: *Rotation, file_ptr: *std.fs.File) ?RotationReason`
+#### `getRotationReason(self: *Rotation, file_ptr: *std.Io.File) ?RotationReason`
 
 Returns why rotation would occur right now (`interval`, `size`, or `interval_and_size`).
 
-#### `shouldRotate(self: *Rotation, file_ptr: *std.fs.File) bool`
+#### `shouldRotate(self: *Rotation, file_ptr: *std.Io.File) bool`
 
 Returns true when any rotation condition is currently met.
 
@@ -240,7 +240,7 @@ Returns remaining seconds until next interval rotation, or `null` if interval ro
 
 Returns the next rotated path without mutating internal state.
 
-#### `forceRotate(self: *Rotation, file_ptr: *std.fs.File) !void`
+#### `forceRotate(self: *Rotation, file_ptr: *std.Io.File) !void`
 
 Forces an immediate rotation regardless of interval or size checks.
 
@@ -289,7 +289,7 @@ pub const RotationConfig = struct {
 | `create_date_subdirs` | `bool` | `false` | Create YYYY/MM/DD subdirs |
 | `file_prefix` | `?[]const u8` | `null` | Prefix for rotated file names |
 | `file_suffix` | `?[]const u8` | `null` | Suffix for rotated file names |
-| `compression_algorithm` | `CompressionAlgorithm` | `.gzip` | Algorithm for compression (gzip, zlib, deflate, zstd v0.1.5+) |
+| `compression_algorithm` | `CompressionAlgorithm` | `.gzip` | Algorithm for compression (gzip, zlib, deflate, zstd v0.1.8+) |
 | `compression_level` | `CompressionLevel` | `.default` | Compression level |
 | `keep_original` | `bool` | `false` | Keep original after compression |
 | `compress_on_retention` | `bool` | `false` | Compress instead of delete |

--- a/docs/api/rules.md
+++ b/docs/api/rules.md
@@ -122,7 +122,7 @@ The rules system augments logging with intelligent diagnostics:
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     const allocator = gpa.allocator();
 
     // Enable ANSI colors
@@ -663,7 +663,8 @@ Format rule messages as JSON:
 var json_buf: std.ArrayList(u8) = .empty;
 defer json_buf.deinit(allocator);
 
-try rules.formatMessagesJson(&messages, json_buf.writer(allocator), true); // pretty=true
+var writer = logly.Utils.ArrayListWriter.init(&json_buf, allocator);
+try rules.formatMessagesJson(&messages, &writer.writer, true); // pretty=true
 
 std.debug.print("{s}\n", .{json_buf.items});
 ```

--- a/docs/api/scheduler.md
+++ b/docs/api/scheduler.md
@@ -176,7 +176,7 @@ pub const SchedulerConfig = struct {
 | `min_age_days_for_compression` | `u64` | `1` | Min age before compression |
 | `max_concurrent_compressions` | `usize` | `2` | Max parallel compressions |
 
-> Note: v0.1.6 expanded compression and archiving support — including LZMA, LZMA2, XZ, TAR.GZ, ZIP, and LZ4 — and added helper utilities (e.g., `Utils.getCompressionExtension()`) and factory presets to simplify usage. Use the `compression_algorithm` and `compression_level` fields (or the `Compression` factory methods) to select the appropriate algorithm and extension for your scheduled compression tasks.
+> Note: v0.1.8 expanded compression and archiving support â€” including LZMA, LZMA2, XZ, TAR.GZ, ZIP, and LZ4 â€” and added helper utilities (e.g., `Utils.getCompressionExtension()`) and factory presets to simplify usage. Use the `compression_algorithm` and `compression_level` fields (or the `Compression` factory methods) to select the appropriate algorithm and extension for your scheduled compression tasks.
 
 
 ### ScheduledTask
@@ -711,7 +711,7 @@ const Scheduler = logly.Scheduler;
 const SchedulerPresets = logly.SchedulerPresets;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -778,7 +778,7 @@ Helper functions for creating common schedules and task configurations.
 |--------|-------------|
 | `hourlyCompression()` | Compression every hour |
 | `everyMinutes(n)` | Every N minutes |
-| `every15Minutes()` | Every 15 minutes (v0.1.5+) |
+| `every15Minutes()` | Every 15 minutes (v0.1.8+) |
 | `every30Minutes()` | Every 30 minutes |
 | `every6Hours()` | Every 6 hours |
 | `every12Hours()` | Every 12 hours |
@@ -786,9 +786,9 @@ Helper functions for creating common schedules and task configurations.
 | `dailyMidnight()` | Daily at midnight |
 | `dailyMaintenance()` | Daily at 2 AM |
 | `weeklyCleanup()` | Weekly on Sunday at 2 AM |
-| `onceAfter(seconds)` | Once after delay (v0.1.5+) |
-| `healthCheckSchedule()` | Every 5 minutes (v0.1.5+) |
-| `metricsSchedule()` | Every minute (v0.1.5+) |
+| `onceAfter(seconds)` | Once after delay (v0.1.8+) |
+| `healthCheckSchedule()` | Every 5 minutes (v0.1.8+) |
+| `metricsSchedule()` | Every minute (v0.1.8+) |
 
 ### Task Config Presets
 
@@ -800,19 +800,19 @@ Helper functions for creating common schedules and task configurations.
 | `compressOnly(path, days)` | Compress only, never delete |
 | `archiveOldLogs(path, compress_days, delete_days)` | Archive with age limits |
 | `aggressiveCleanup(path, days, max_files)` | Compress + file count limit |
-| `hourlyArchive(path)` | Compress files older than 1 day (v0.1.5+) |
-| `compressOnRotation(path)` | Compress just-rotated files (v0.1.5+) |
-| `sizeBasedCompression(path, bytes)` | Compress when size exceeds threshold (v0.1.5+) |
-| `diskUsageTriggered(path, percent)` | Compress when disk usage high (v0.1.5+) |
-| `lowDiskSpaceTriggered(path, min_free)` | Compress when disk space low (v0.1.5+) |
-| `recursiveCompression(path, days)` | Recursive directory compression (v0.1.5+) |
+| `hourlyArchive(path)` | Compress files older than 1 day (v0.1.8+) |
+| `compressOnRotation(path)` | Compress just-rotated files (v0.1.8+) |
+| `sizeBasedCompression(path, bytes)` | Compress when size exceeds threshold (v0.1.8+) |
+| `diskUsageTriggered(path, percent)` | Compress when disk usage high (v0.1.8+) |
+| `lowDiskSpaceTriggered(path, min_free)` | Compress when disk space low (v0.1.8+) |
+| `recursiveCompression(path, days)` | Recursive directory compression (v0.1.8+) |
 
 ```zig
 pub const SchedulerPresets = struct {
     // Schedules
     pub fn hourlyCompression() Schedule;
     pub fn everyMinutes(n: u64) Schedule;
-    pub fn every15Minutes() Schedule;          // v0.1.5+
+    pub fn every15Minutes() Schedule;          // v0.1.8+
     pub fn every30Minutes() Schedule;
     pub fn every6Hours() Schedule;
     pub fn every12Hours() Schedule;
@@ -820,9 +820,9 @@ pub const SchedulerPresets = struct {
     pub fn dailyMidnight() Schedule;
     pub fn dailyMaintenance() Schedule;
     pub fn weeklyCleanup() Schedule;
-    pub fn onceAfter(seconds: u64) Schedule;   // v0.1.5+
-    pub fn healthCheckSchedule() Schedule;     // v0.1.5+
-    pub fn metricsSchedule() Schedule;         // v0.1.5+
+    pub fn onceAfter(seconds: u64) Schedule;   // v0.1.8+
+    pub fn healthCheckSchedule() Schedule;     // v0.1.8+
+    pub fn metricsSchedule() Schedule;         // v0.1.8+
 
     // Task Configurations
     pub fn dailyCleanup(path: []const u8, max_age_days: u64) TaskConfig;
@@ -831,12 +831,12 @@ pub const SchedulerPresets = struct {
     pub fn compressOnly(path: []const u8, min_age_days: u64) TaskConfig;
     pub fn archiveOldLogs(path: []const u8, compress_days: u64, delete_days: u64) TaskConfig;
     pub fn aggressiveCleanup(path: []const u8, max_age_days: u64, max_files: usize) TaskConfig;
-    pub fn hourlyArchive(path: []const u8) TaskConfig;             // v0.1.5+
-    pub fn compressOnRotation(path: []const u8) TaskConfig;        // v0.1.5+
-    pub fn sizeBasedCompression(path: []const u8, bytes: u64) TaskConfig;  // v0.1.5+
-    pub fn diskUsageTriggered(path: []const u8, percent: u8) TaskConfig;   // v0.1.5+
-    pub fn lowDiskSpaceTriggered(path: []const u8, min_free: u64) TaskConfig;  // v0.1.5+
-    pub fn recursiveCompression(path: []const u8, days: u64) TaskConfig;   // v0.1.5+
+    pub fn hourlyArchive(path: []const u8) TaskConfig;             // v0.1.8+
+    pub fn compressOnRotation(path: []const u8) TaskConfig;        // v0.1.8+
+    pub fn sizeBasedCompression(path: []const u8, bytes: u64) TaskConfig;  // v0.1.8+
+    pub fn diskUsageTriggered(path: []const u8, percent: u8) TaskConfig;   // v0.1.8+
+    pub fn lowDiskSpaceTriggered(path: []const u8, min_free: u64) TaskConfig;  // v0.1.8+
+    pub fn recursiveCompression(path: []const u8, days: u64) TaskConfig;   // v0.1.8+
 };
 ```
 

--- a/docs/api/scheduler.md
+++ b/docs/api/scheduler.md
@@ -176,7 +176,7 @@ pub const SchedulerConfig = struct {
 | `min_age_days_for_compression` | `u64` | `1` | Min age before compression |
 | `max_concurrent_compressions` | `usize` | `2` | Max parallel compressions |
 
-> Note: v0.1.8 expanded compression and archiving support â€” including LZMA, LZMA2, XZ, TAR.GZ, ZIP, and LZ4 â€” and added helper utilities (e.g., `Utils.getCompressionExtension()`) and factory presets to simplify usage. Use the `compression_algorithm` and `compression_level` fields (or the `Compression` factory methods) to select the appropriate algorithm and extension for your scheduled compression tasks.
+> Note: v0.1.6 expanded compression and archiving support — including LZMA, LZMA2, XZ, TAR.GZ, ZIP, and LZ4 — and added helper utilities (e.g., `Utils.getCompressionExtension()`) and factory presets to simplify usage. Use the `compression_algorithm` and `compression_level` fields (or the `Compression` factory methods) to select the appropriate algorithm and extension for your scheduled compression tasks.
 
 
 ### ScheduledTask

--- a/docs/api/telemetry.md
+++ b/docs/api/telemetry.md
@@ -13,7 +13,7 @@ Logly provides comprehensive OpenTelemetry (OTEL) support for distributed tracin
 - **Network Export**: UDP/TCP/HTTP/gRPC transport protocols for span and metric export
 - **Export Modes**: Synchronous, async buffered, batch, and network export modes
 - **Span Processor Semantics**: `span_processor_type` affects export behavior: `.simple` keeps completed spans pending until an explicit `exportSpans()` or `flush()` call, while `.batch` will automatically export spans when the batch size or timeout is reached.
-- **Note (v0.1.6)**: Fixed an OTLP exporter compile-time issue (removed an unnecessary discard in `writeOtlpSpan`) and clarified span-processor semantics; telemetry now builds cleanly across targets.
+- **Note (v0.1.8)**: Fixed an OTLP exporter compile-time issue (removed an unnecessary discard in `writeOtlpSpan`) and clarified span-processor semantics; telemetry now builds cleanly across targets.
 - **Exporter Statistics**: Real-time monitoring of export performance with atomic counters
 - **Resource Detection**: Automatic detection of service metadata and resource attributes
 - **Sampling Strategies**: Four sampling algorithms (always_on, always_off, trace_id_ratio, parent_based)
@@ -75,8 +75,8 @@ pub const Telemetry = struct {
     on_span_end: ?*const fn ([]const u8, u64) void,
     on_metric_recorded: ?*const fn ([]const u8, f64) void,
     on_error: ?*const fn ([]const u8) void,
-    network_socket: ?std.posix.socket_t,
-    network_address: ?std.net.Address,
+    network_socket: ?std.Io.net.Socket,
+    network_address: ?std.Io.net.IpAddress,
     batch_buffer: std.ArrayList(u8),
     last_batch_export: i64,
     
@@ -1416,7 +1416,7 @@ Common errors:
 
 ## Compatibility
 
-- Zig: 0.15.2+
+- Zig: 0.16.0+
 - OpenTelemetry: Specification 1.0+
 - Platforms: Linux, macOS, Windows (x86_64, aarch64, x86)
 

--- a/docs/api/thread-pool.md
+++ b/docs/api/thread-pool.md
@@ -684,7 +684,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/api/update-checker.md
+++ b/docs/api/update-checker.md
@@ -129,7 +129,7 @@ const logly = @import("logly");
 const UpdateChecker = logly.UpdateChecker;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){}; 
+    var gpa = std.heap.DebugAllocator(.{}){}; 
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -169,11 +169,11 @@ pub fn main() !void {
 
 ## Recent Changes
 
-### v0.1.7
+### v0.1.8
 
-- Updated examples and version references to the latest release (`0.1.7`).
+- Updated examples and version references to the latest release (`0.1.8`).
 
-### v0.1.6
+### v0.1.8
 
 - Fixed a telemetry compilation issue: Resolved a compile-time error in the telemetry module (OTLP exporter) by removing an unnecessary discard of the `self` parameter in `writeOtlpSpan`. This ensures the telemetry feature compiles cleanly across targets and prevents build failures when telemetry is enabled.
 

--- a/docs/examples/advanced-config.md
+++ b/docs/examples/advanced-config.md
@@ -43,7 +43,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/allocator-strategies.md
+++ b/docs/examples/allocator-strategies.md
@@ -1,10 +1,10 @@
 ---
 title: Allocator Strategies Example
-description: Compare the default GeneralPurposeAllocator logger flow with optional arena allocation in Logly.zig.
+description: Compare the default DebugAllocator logger flow with optional arena allocation in Logly.zig.
 head:
   - - meta
     - name: keywords
-      content: allocator strategies, generalpurposeallocator, arena allocation, zig logging memory management
+      content: allocator strategies, DebugAllocator, arena allocation, zig logging memory management
   - - meta
     - property: og:title
       content: Allocator Strategies Example | Logly.zig
@@ -14,7 +14,7 @@ head:
 
 This example demonstrates both supported allocator strategies:
 
-- Default: logger uses the allocator passed to `Logger.init(...)` or `Logger.initWithConfig(...)` (typically `GeneralPurposeAllocator`).
+- Default: logger uses the allocator passed to `Logger.init(...)` or `Logger.initWithConfig(...)` (typically `DebugAllocator`).
 - Optional: arena allocation enabled via explicit config field (`use_arena_allocator`) or alias builder (`withArenaAllocator()`) for high-throughput temporary allocations.
 
 ## Source Code
@@ -66,7 +66,7 @@ fn runArenaAllocatorAliasExample(allocator: std.mem.Allocator) !void {
   }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -98,7 +98,7 @@ Difference:
 - `config.use_arena_allocator = true` mutates an existing config variable.
 - `config = config.withArenaAllocator()` returns a modified copy (reassign it).
 
-All examples in this repository initialize Logly with `std.heap.GeneralPurposeAllocator` and then optionally enable arena scratch allocation per logger config.
+All examples in this repository initialize Logly with `std.heap.DebugAllocator` and then optionally enable arena scratch allocation per logger config.
 
 ## Build and Run
 

--- a/docs/examples/async-logging.md
+++ b/docs/examples/async-logging.md
@@ -40,7 +40,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/basic.md
+++ b/docs/examples/basic.md
@@ -24,7 +24,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -96,4 +96,4 @@ zig build run-basic
 
 ## Related
 
-- [Allocator Strategies Example](allocator-strategies.md) - Default GeneralPurposeAllocator workflow and optional arena allocation.
+- [Allocator Strategies Example](allocator-strategies.md) - Default DebugAllocator workflow and optional arena allocation.

--- a/docs/examples/callbacks.md
+++ b/docs/examples/callbacks.md
@@ -27,7 +27,7 @@ fn logCallback(record: *const logly.Record) !void {
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/color-control.md
+++ b/docs/examples/color-control.md
@@ -26,7 +26,7 @@ pub fn main() !void {
     // No-op on Linux/macOS
     _ = logly.Terminal.enableAnsiColors();
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -228,7 +228,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -267,7 +267,7 @@ pub fn main() !void {
 ```
 
 ```zig
-const is_tty = std.io.getStdOut().isTty();
+const is_tty = std.Io.getStdOut().isTty();
 const force_no_color = std.process.getEnvVarOwned(allocator, "NO_COLOR") catch null;
 
 var config = logly.Config.default();

--- a/docs/examples/compression.md
+++ b/docs/examples/compression.md
@@ -276,13 +276,13 @@ defer allocator.free(fast_compressed);
 
 | Algorithm | Speed | Ratio | Use Case |
 |-----------|-------|-------|----------|
-| `deflate` | â˜…â˜…â˜…â˜… | â˜…â˜…â˜… | General purpose |
-| `zstd` | â˜…â˜…â˜…â˜…â˜… | â˜…â˜…â˜…â˜… | High performance |
-| `lzma` | â˜…â˜… | â˜…â˜…â˜…â˜…â˜… | Long-term storage |
-| `xz` | â˜…â˜… | â˜…â˜…â˜…â˜…â˜… | Distribution |
-| `zip` | â˜…â˜…â˜…â˜… | â˜…â˜…â˜… | Cross-platform |
-| `tar_gz` | â˜…â˜…â˜… | â˜…â˜…â˜…â˜… | Unix archives |
-| `lz4` | â˜…â˜…â˜…â˜…â˜… | â˜…â˜… | Real-time |
+| `deflate` | ★★★★ | ★★★ | General purpose |
+| `zstd` | ★★★★★ | ★★★★ | High performance |
+| `lzma` | ★★ | ★★★★★ | Long-term storage |
+| `xz` | ★★ | ★★★★★ | Distribution |
+| `zip` | ★★★★ | ★★★ | Cross-platform |
+| `tar_gz` | ★★★ | ★★★★ | Unix archives |
+| `lz4` | ★★★★★ | ★★ | Real-time |
 
 ## See Also
 

--- a/docs/examples/compression.md
+++ b/docs/examples/compression.md
@@ -12,7 +12,7 @@ head:
 
 # Compression Example
 
-This example demonstrates log compression features in Logly, including GZIP, ZSTD (v0.1.5+), LZMA, XZ, TAR.GZ, ZIP, LZ4, and the Streaming API.
+This example demonstrates log compression features in Logly, including GZIP, ZSTD (v0.1.8+), LZMA, XZ, TAR.GZ, ZIP, LZ4, and the Streaming API.
 
 ## Source Code
 
@@ -26,7 +26,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -49,7 +49,7 @@ pub fn main() !void {
     const decompressed = try comp.decompress(compressed);
     defer allocator.free(decompressed);
     std.debug.print("   Decompressed size: {d} bytes\n", .{decompressed.len});
-    std.debug.print("   Data integrity: {s}\n\n", .{if (std.mem.eql(u8, test_data, decompressed)) "✓ Verified" else "✗ Failed"});
+    std.debug.print("   Data integrity: {s}\n\n", .{if (std.mem.eql(u8, test_data, decompressed)) "âœ“ Verified" else "âœ— Failed"});
 
     // Example 2: Compression presets
     std.debug.print("2. Compression Presets\n", .{});
@@ -71,8 +71,8 @@ pub fn main() !void {
 
     std.debug.print("   GZIP compressed size: {d} bytes\n\n", .{gzip_compressed.len});
 
-    // Example 7: Zstd Compression (v0.1.5+)
-    std.debug.print("7. Zstd Compression (v0.1.5+)\n", .{});
+    // Example 7: Zstd Compression (v0.1.8+)
+    std.debug.print("7. Zstd Compression (v0.1.8+)\n", .{});
     std.debug.print("   ---------------------------\n", .{});
 
     var zstd_comp = logly.Compression.zstdCompression(allocator);
@@ -88,7 +88,7 @@ pub fn main() !void {
     const zstd_decompressed = try zstd_comp.decompress(zstd_compressed);
     defer allocator.free(zstd_decompressed);
     std.debug.print("   Zstd decompressed: {d} bytes\n", .{zstd_decompressed.len});
-    std.debug.print("   Data integrity: {s}\n\n", .{if (std.mem.eql(u8, zstd_data, zstd_decompressed)) "✓ Verified" else "✗ Failed"});
+    std.debug.print("   Data integrity: {s}\n\n", .{if (std.mem.eql(u8, zstd_data, zstd_decompressed)) "âœ“ Verified" else "âœ— Failed"});
 
     // Example 8: Streaming Compression
     std.debug.print("8. Streaming Compression\n", .{});
@@ -98,11 +98,12 @@ pub fn main() !void {
     defer stream_comp.deinit();
 
     const stream_data = "Data to be compressed via stream" ** 5;
-    var input_stream = std.io.fixedBufferStream(stream_data);
+    var input_stream = std.Io.Reader.fixed(stream_data);
     var output_buffer: std.ArrayList(u8) = .empty;
     defer output_buffer.deinit(allocator);
 
-    try stream_comp.compressStream(input_stream.reader(), output_buffer.writer(allocator));
+    var output_writer = logly.Utils.ArrayListWriter.init(&output_buffer, allocator);
+    try stream_comp.compressStream(&input_stream, &output_writer.writer);
     std.debug.print("   Stream compressed size: {d} bytes\n", .{output_buffer.items.len});
 
     // Example 9: Directory Compression
@@ -128,7 +129,7 @@ zig build run-compression
    Original data size: 470 bytes
    Compressed size: 77 bytes
    Decompressed size: 470 bytes
-   Data integrity: ✓ Verified
+   Data integrity: âœ“ Verified
 
 ...
 
@@ -139,7 +140,7 @@ zig build run-compression
 7. Streaming Compression
    ---------------------
    Stream compressed size: 57 bytes
-   Stream decompressed verified: ✓ Yes
+   Stream decompressed verified: âœ“ Yes
 
 8. Directory Compression
    ---------------------
@@ -208,7 +209,7 @@ config.rotation = .{
 };
 ```
 
-## New Algorithms (v0.1.6+)
+## New Algorithms (v0.1.8+)
 
 ### LZMA/XZ Compression
 
@@ -275,13 +276,13 @@ defer allocator.free(fast_compressed);
 
 | Algorithm | Speed | Ratio | Use Case |
 |-----------|-------|-------|----------|
-| `deflate` | ★★★★ | ★★★ | General purpose |
-| `zstd` | ★★★★★ | ★★★★ | High performance |
-| `lzma` | ★★ | ★★★★★ | Long-term storage |
-| `xz` | ★★ | ★★★★★ | Distribution |
-| `zip` | ★★★★ | ★★★ | Cross-platform |
-| `tar_gz` | ★★★ | ★★★★ | Unix archives |
-| `lz4` | ★★★★★ | ★★ | Real-time |
+| `deflate` | â˜…â˜…â˜…â˜… | â˜…â˜…â˜… | General purpose |
+| `zstd` | â˜…â˜…â˜…â˜…â˜… | â˜…â˜…â˜…â˜… | High performance |
+| `lzma` | â˜…â˜… | â˜…â˜…â˜…â˜…â˜… | Long-term storage |
+| `xz` | â˜…â˜… | â˜…â˜…â˜…â˜…â˜… | Distribution |
+| `zip` | â˜…â˜…â˜…â˜… | â˜…â˜…â˜… | Cross-platform |
+| `tar_gz` | â˜…â˜…â˜… | â˜…â˜…â˜…â˜… | Unix archives |
+| `lz4` | â˜…â˜…â˜…â˜…â˜… | â˜…â˜… | Real-time |
 
 ## See Also
 

--- a/docs/examples/context.md
+++ b/docs/examples/context.md
@@ -21,7 +21,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/custom-colors.md
+++ b/docs/examples/custom-colors.md
@@ -32,7 +32,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -78,7 +78,7 @@ pub fn main() !void {
 | FAIL     | 35        | Magenta         |
 | CRITICAL | 91        | Bright Red      |
 
-## Color Variants (v0.1.5)
+## Color Variants (v0.1.8)
 
 Each level now supports multiple color variants:
 

--- a/docs/examples/custom-levels-full.md
+++ b/docs/examples/custom-levels-full.md
@@ -24,7 +24,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/custom-theme.md
+++ b/docs/examples/custom-theme.md
@@ -25,7 +25,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/diagnostics.md
+++ b/docs/examples/diagnostics.md
@@ -19,7 +19,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/distributed.md
+++ b/docs/examples/distributed.md
@@ -17,7 +17,7 @@ const logly = @import("logly");
 const Config = logly.Config;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/file-logging.md
+++ b/docs/examples/file-logging.md
@@ -21,7 +21,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/filtering.md
+++ b/docs/examples/filtering.md
@@ -21,7 +21,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -135,7 +135,7 @@ logger.setFilter(&filter);
 - **Debugging**: Enable debug for specific modules only
 - **Security**: Filter out PII-containing messages
 
-## New Features (v0.1.5)
+## New Features (v0.1.8)
  
  ### Improved Regex Engine
  

--- a/docs/examples/formatted-logging.md
+++ b/docs/examples/formatted-logging.md
@@ -27,7 +27,7 @@ pub fn main() !void {
     // Enable ANSI colors on Windows
     _ = logly.Terminal.enableAnsiColors();
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/json-extended.md
+++ b/docs/examples/json-extended.md
@@ -24,7 +24,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/json.md
+++ b/docs/examples/json.md
@@ -24,7 +24,7 @@ pub fn main() !void {
     // Enable ANSI colors on Windows
     _ = logly.Terminal.enableAnsiColors();
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/metrics.md
+++ b/docs/examples/metrics.md
@@ -22,7 +22,7 @@ const logly = @import("logly");
 const Metrics = logly.Metrics;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/module-levels.md
+++ b/docs/examples/module-levels.md
@@ -24,7 +24,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/network-logging.md
+++ b/docs/examples/network-logging.md
@@ -29,7 +29,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/redaction.md
+++ b/docs/examples/redaction.md
@@ -22,7 +22,7 @@ const logly = @import("logly");
 const Redactor = logly.Redactor;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -164,13 +164,13 @@ defer allocator.free(message);
 4. **Layer defenses** - Use redaction with encryption and access controls
 5. **Document patterns** - Maintain list of redaction rules for compliance
 
-## New Features (v0.1.5)
+## New Features (v0.1.8)
  
  ### Improved Regex Engine
  
  Redaction now supports a production-ready regex-like engine for pattern matching (see [Redaction Guide](/guide/redaction) for details).
  
-## New Compliance Presets (v0.1.5)
+## New Compliance Presets (v0.1.8)
 
 ```zig
 const RedactionPresets = logly.RedactionPresets;

--- a/docs/examples/rotation.md
+++ b/docs/examples/rotation.md
@@ -12,7 +12,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     const allocator = gpa.allocator();
 
     var logger = try logly.Logger.init(allocator, .{});

--- a/docs/examples/rules.md
+++ b/docs/examples/rules.md
@@ -36,7 +36,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -248,7 +248,8 @@ config.rules.console_output = false;
 var json_buf: std.ArrayList(u8) = .empty;
 defer json_buf.deinit(allocator);
 
-try rules.formatMessagesJson(&messages, json_buf.writer(allocator), true);
+var writer = logly.Utils.ArrayListWriter.init(&json_buf, allocator);
+try rules.formatMessagesJson(&messages, &writer.writer, true);
 ```
 
 ```json

--- a/docs/examples/sampling.md
+++ b/docs/examples/sampling.md
@@ -23,7 +23,7 @@ const Sampler = logly.Sampler;
 const Config = logly.Config;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -84,7 +84,7 @@ fn onRateExceeded(count: u32, max: u32) void {
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     const allocator = gpa.allocator();
 
     var sampler = Sampler.init(allocator, .{ .rate_limit = .{

--- a/docs/examples/scheduler.md
+++ b/docs/examples/scheduler.md
@@ -46,7 +46,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/sink-formats.md
+++ b/docs/examples/sink-formats.md
@@ -24,7 +24,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/telemetry.md
+++ b/docs/examples/telemetry.md
@@ -24,7 +24,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/thread-pool.md
+++ b/docs/examples/thread-pool.md
@@ -45,7 +45,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/time.md
+++ b/docs/examples/time.md
@@ -24,7 +24,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/tracing.md
+++ b/docs/examples/tracing.md
@@ -39,7 +39,7 @@ const logly = @import("logly");
 const Config = logly.Config;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/examples/write-modes.md
+++ b/docs/examples/write-modes.md
@@ -37,7 +37,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -71,7 +71,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -105,7 +105,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/guide/arena-allocation.md
+++ b/docs/guide/arena-allocation.md
@@ -18,7 +18,7 @@ head:
 Logly.zig supports optional arena allocation for improved performance in high-throughput logging scenarios. Arena allocation reduces memory allocation overhead by batching temporary allocations and releasing them efficiently.
 
 By default, arena allocation is disabled (`use_arena_allocator = false`) and the logger uses the allocator passed to `Logger.init(...)` / `Logger.initWithConfig(...)`.
-In most applications, that allocator is `std.heap.GeneralPurposeAllocator`.
+In most applications, that allocator is `std.heap.DebugAllocator`.
 
 ## Overview
 
@@ -36,7 +36,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
 
     // Configure logger with arena allocator
@@ -72,7 +72,7 @@ If your application already uses arena allocation (for example, per-request memo
 ```zig
 const std = @import("std");
 
-var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+var gpa = std.heap.DebugAllocator(.{}){};
 defer _ = gpa.deinit();
 
 // Application-level arena (independent from logger internal arena)
@@ -178,7 +178,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
 
     const config = logly.Config{
@@ -254,7 +254,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
 
     // Production configuration with arena allocation

--- a/docs/guide/callbacks.md
+++ b/docs/guide/callbacks.md
@@ -501,9 +501,9 @@ Track callback execution time:
 
 ```zig
 fn monitoredCallback(record: *const logly.Record) void {
-    const start = std.time.nanoTimestamp();
+    const start = logly.Utils.currentNanos();
     defer {
-        const elapsed = std.time.nanoTimestamp() - start;
+        const elapsed = logly.Utils.currentNanos() - start;
         if (elapsed > 1_000_000) { // >1ms
             std.debug.print("⚠️  Slow callback: {d}μs\n", .{elapsed / 1000});
         }
@@ -560,7 +560,7 @@ const MonitoringSystem = struct {
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
     

--- a/docs/guide/colors.md
+++ b/docs/guide/colors.md
@@ -21,11 +21,11 @@ Logly-Zig provides comprehensive ANSI color support for console output, with opt
 
 | Platform | Color Support | Notes |
 |----------|--------------|-------|
-| Linux | ✅ Native | Works out of the box |
-| macOS | ✅ Native | Works out of the box |
-| Windows 10+ | ✅ Requires init | Call `Terminal.enableAnsiColors()` |
-| VS Code Terminal | ✅ Full | Works on all platforms |
-| Windows Console | ⚠️ Legacy | May need VT processing enabled |
+| Linux | âœ… Native | Works out of the box |
+| macOS | âœ… Native | Works out of the box |
+| Windows 10+ | âœ… Requires init | Call `Terminal.enableAnsiColors()` |
+| VS Code Terminal | âœ… Full | Works on all platforms |
+| Windows Console | âš ï¸ Legacy | May need VT processing enabled |
 
 ## Enabling Colors
 
@@ -154,7 +154,7 @@ const logly = @import("logly");
 pub fn main() !void {
     _ = logly.Terminal.enableAnsiColors();
     
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     const allocator = gpa.allocator();
     
     const logger = try logly.Logger.init(allocator);
@@ -176,7 +176,7 @@ pub fn main() !void {
 }
 ```
 
-## Enhanced Color Options (v0.1.5)
+## Enhanced Color Options (v0.1.8)
 
 ### Level Color Variants
 
@@ -225,7 +225,7 @@ const reverse = Colors.Style.reverse;  // "7"
 
 ### Theme Presets
 
-Logly v0.1.5 includes multiple color theme presets:
+Logly v0.1.8 includes multiple color theme presets:
 
 ```zig
 const Formatter = logly.Formatter;
@@ -234,7 +234,7 @@ const Formatter = logly.Formatter;
 const default_theme = Formatter.Theme{};           // Standard colors
 const bright_theme = Formatter.Theme.bright();     // Bold/bright colors
 const dim_theme = Formatter.Theme.dim();           // Dim colors
-const underlined_theme = Formatter.Theme.underlined(); // Underlined colors (v0.1.5)
+const underlined_theme = Formatter.Theme.underlined(); // Underlined colors (v0.1.8)
 const minimal_theme = Formatter.Theme.minimal();   // Subtle grays
 const neon_theme = Formatter.Theme.neon();         // Vivid 256-colors
 const pastel_theme = Formatter.Theme.pastel();     // Soft colors
@@ -436,7 +436,7 @@ pub fn main() !void {
     // Enable Windows ANSI support
     _ = logly.Terminal.enableAnsiColors();
     
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
     

--- a/docs/guide/colors.md
+++ b/docs/guide/colors.md
@@ -21,11 +21,11 @@ Logly-Zig provides comprehensive ANSI color support for console output, with opt
 
 | Platform | Color Support | Notes |
 |----------|--------------|-------|
-| Linux | âœ… Native | Works out of the box |
-| macOS | âœ… Native | Works out of the box |
-| Windows 10+ | âœ… Requires init | Call `Terminal.enableAnsiColors()` |
-| VS Code Terminal | âœ… Full | Works on all platforms |
-| Windows Console | âš ï¸ Legacy | May need VT processing enabled |
+| Linux | ✅ Native | Works out of the box |
+| macOS | ✅ Native | Works out of the box |
+| Windows 10+ | ✅ Requires init | Call `Terminal.enableAnsiColors()` |
+| VS Code Terminal | ✅ Full | Works on all platforms |
+| Windows Console | ⚠️ Legacy | May need VT processing enabled |
 
 ## Enabling Colors
 

--- a/docs/guide/comparison.md
+++ b/docs/guide/comparison.md
@@ -17,64 +17,64 @@ This page provides a comprehensive comparison between Logly.zig and other Zig lo
 
 | Feature | logly.zig | nexlog | log.zig | std.log |
 |:--------|:----------|:-------|:--------|:--------|
-| Current Version | 0.1.7 | 0.7.2 | 0.0.0 | Built-in |
-| Min Zig Version | 0.15.0+ | 0.14, 0.15-dev | 0.11+ | Any |
+| Current Version | 0.1.8 | 0.7.2 | 0.0.0 | Built-in |
+| Min Zig Version | 0.16.0+ | 0.14, 0.15-dev | 0.11+ | Any |
 | API Style | User-friendly | Builder/Fluent | Pool/Fluent | Basic/Manual |
-| Structured Logging | ✅ Automatic | ✅ JSON/logfmt | ✅ JSON/logfmt | ❌ Manual |
-| File Formats (.json, .txt, .log) | ✅ Automatic | ✅ | ✅ | ❌ |
-| Async Logging | ✅ Automatic (ring buffer, workers) | ⚠ Basic | ❌ | ❌ |
-| Thread Safety | ✅ Automatic | ⚠ Partial | ⚠ Pool-only | ✅ Basic |
-| Single/Multi-Thread Support | ✅ | ❌ | ❌ | ✅ Manual |
-| Multiple Sinks | ✅ Automatic | ✅ | ⚠ Limited | ❌ |
-| File Logging | ✅ Automatic | ✅ | ✅ | ❌ Manual |
-| File Rotation | ✅ Automatic (Time + Size) | ✅ Size | ❌ | ❌ |
-| Retention Policy | ✅ Automatic | ❌ | ❌ | ❌ |
-| Compression | ✅ Automatic (gzip/zlib/deflate/zstd, lzma, lzma2, xz, tar.gz, zip, lz4) | ❌ | ❌ | ❌ |
-| Zstd Compression (v0.1.5+) | ✅ Levels 1-22, presets, batch ops | ❌ | ❌ | ❌ |
-| Rotation Presets (v0.1.5+) | ✅ 25+ presets (time/size/hybrid/production) | ❌ | ❌ | ❌ |
-| Performance Defaults (v0.1.6+) | ✅ Optimized auto_flush/callbacks defaults | ❌ | ❌ | ❌ |
-| Network Logging | ✅ Automatic (TCP/UDP) | ❌ | ❌ | ❌ |
-| Stack Traces | ✅ Automatic | ❌ | ❌ | ❌ Manual |
-| Redaction (PII) | ✅ Automatic | ❌ | ❌ | ❌ |
-| Sampling/Rate Limit | ✅ Automatic | ❌ | ❌ | ❌ |
-| Distributed Tracing | ✅ Automatic (Trace/Span/Correlation IDs) + Callbacks | ⚠ Context only | ❌ | ❌ |
-| OpenTelemetry (v0.1.4+) | ✅ Full OTLP/Jaeger/Zipkin/Datadog/AWS/Azure | ❌ | ❌ | ❌ |
-| Metrics | ✅ Automatic | ❌ | ⚠ Prometheus | ❌ |
-| System Diagnostics | ✅ Automatic | ❌ | ❌ | ❌ |
-| Filtering | ✅ Automatic | ❌ | ❌ | ✅ Manual |
-| Scheduled Cleaning | ✅ Automatic | ❌ | ❌ | ❌ |
-| Dynamic Path | ✅ Automatic | ❌ | ❌ | ❌ |
-| Module-level Config | ✅ | ❌ | ❌ | ✅ Manual |
-| Custom Log Levels | ✅ | ❌ | ❌ | ❌ |
-| Rules System (v0.1.0+) | ✅ Template-triggered messages | ❌ | ❌ | ❌ |
-| Bare-Metal Support | ✅ | ❌ | ❌ | ✅ |
-| Prebuilt Libraries | ✅ | ❌ | ❌ | ✅ |
-| Documentation Site | ✅ | ❌ | ❌ | ✅ |
-| Auto-Update Checker | ✅ | ❌ | ❌ | ❌ |
-| CI/CodeQL | ✅ | ⚠ | ❌ | ✅ |
+| Structured Logging | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ JSON/logfmt | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ JSON/logfmt | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual |
+| File Formats (.json, .txt, .log) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Async Logging | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic (ring buffer, workers) | ÃƒÂ¢Ã…Â¡Ã‚Â  Basic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Thread Safety | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã…Â¡Ã‚Â  Partial | ÃƒÂ¢Ã…Â¡Ã‚Â  Pool-only | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Basic |
+| Single/Multi-Thread Support | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Manual |
+| Multiple Sinks | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã…Â¡Ã‚Â  Limited | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| File Logging | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual |
+| File Rotation | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic (Time + Size) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Size | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Retention Policy | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Compression | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic (gzip/zlib/deflate/zstd, lzma, lzma2, xz, tar.gz, zip, lz4) | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Zstd Compression (v0.1.8+) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Levels 1-22, presets, batch ops | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Rotation Presets (v0.1.8+) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ 25+ presets (time/size/hybrid/production) | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Performance Defaults (v0.1.8+) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Optimized auto_flush/callbacks defaults | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Network Logging | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic (TCP/UDP) | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Stack Traces | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual |
+| Redaction (PII) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Sampling/Rate Limit | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Distributed Tracing | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic (Trace/Span/Correlation IDs) + Callbacks | ÃƒÂ¢Ã…Â¡Ã‚Â  Context only | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| OpenTelemetry (v0.1.4+) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Full OTLP/Jaeger/Zipkin/Datadog/AWS/Azure | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Metrics | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…Â¡Ã‚Â  Prometheus | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| System Diagnostics | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Filtering | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Manual |
+| Scheduled Cleaning | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Dynamic Path | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Module-level Config | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Manual |
+| Custom Log Levels | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Rules System (v0.1.0+) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Template-triggered messages | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Bare-Metal Support | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ |
+| Prebuilt Libraries | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ |
+| Documentation Site | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ |
+| Auto-Update Checker | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| CI/CodeQL | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã…Â¡Ã‚Â  | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ |
 | License | MIT | MIT | MIT | MIT |
 
 ### Standard Library Comparison (Automatic vs Manual)
 
 | Feature | logly.zig | std.log | Notes |
 |:--------|:----------|:--------|:------|
-| Log Levels | ✅ 10 levels (trace → fatal) | 4 levels (debug, info, warn, err) | logly.zig has more granularity |
-| Custom Levels | ✅ Automatic | ❌ | Define your own levels |
-| Colored Output | ✅ Automatic | ❌ | Cross-platform ANSI colors |
-| JSON Output | ✅ Automatic | ❌ Manual | Built-in JSON formatter |
-| File Output | ✅ Automatic | ❌ Manual (stderr only) | Must implement manually for std.log |
-| Async Logging | ✅ Automatic | ❌ Manual | Ring buffer with workers |
-| Context Binding | ✅ Automatic | ❌ Manual | Persistent fields across logs |
-| Formatted Logging | ✅ Automatic templates | ✅ Manual format strings | std.log uses basic printf-style |
-| Thread Safety | ✅ Automatic (advanced) | ✅ Basic | logly.zig has lock-free options |
-| Performance Tuning | ✅ Automatic presets | ❌ Manual | Production/development presets |
-| File Rotation | ✅ Automatic | ❌ Manual | Time + size based rotation |
-| Compression | ✅ Automatic | ❌ Manual | gzip/zlib/zstd support |
-| Network Logging | ✅ Automatic | ❌ Manual | TCP/UDP sinks |
-| Redaction | ✅ Automatic | ❌ Manual | PII masking built-in |
-| Metrics | ✅ Automatic | ❌ Manual | Built-in counters and stats |
-| Distributed Tracing | ✅ Automatic | ❌ Manual | Trace/span/correlation IDs |
-| Rules System | ✅ Automatic triggers | ❌ | Template-based diagnostic messages |
+| Log Levels | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ 10 levels (trace ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ fatal) | 4 levels (debug, info, warn, err) | logly.zig has more granularity |
+| Custom Levels | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | Define your own levels |
+| Colored Output | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | Cross-platform ANSI colors |
+| JSON Output | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | Built-in JSON formatter |
+| File Output | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual (stderr only) | Must implement manually for std.log |
+| Async Logging | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | Ring buffer with workers |
+| Context Binding | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | Persistent fields across logs |
+| Formatted Logging | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic templates | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Manual format strings | std.log uses basic printf-style |
+| Thread Safety | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic (advanced) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Basic | logly.zig has lock-free options |
+| Performance Tuning | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic presets | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | Production/development presets |
+| File Rotation | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | Time + size based rotation |
+| Compression | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | gzip/zlib/zstd support |
+| Network Logging | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | TCP/UDP sinks |
+| Redaction | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | PII masking built-in |
+| Metrics | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | Built-in counters and stats |
+| Distributed Tracing | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | Trace/span/correlation IDs |
+| Rules System | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic triggers | ÃƒÂ¢Ã‚ÂÃ…â€™ | Template-based diagnostic messages |
 
 ::: info Automatic vs Manual
 - **Automatic**: Feature works out-of-the-box with configuration
@@ -95,9 +95,9 @@ This page provides a comprehensive comparison between Logly.zig and other Zig lo
 | Async high-throughput (ops/sec) | **36,483,035** | ~180,000 | N/A | N/A |
 | Multi-threaded (4 threads, ops/sec) | **51,211** | ~22,000 | ~18,000 | N/A (based on implementation) |
 | Multi-threaded JSON (4 threads, ops/sec) | **37,412** | ~14,000 | ~12,000 | N/A |
-| Avg latency – minimal config (ns) | **8,758** | ~24,000 | ~8,000 | N/A (based on implementation) |
-| Avg latency – JSON compact (ns) | **18,815** | ~37,000 | ~28,000 | N/A |
-| Avg latency – production preset (ns) | **28,278** | ~45,000 | ~35,000 | N/A |
+| Avg latency ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“ minimal config (ns) | **8,758** | ~24,000 | ~8,000 | N/A (based on implementation) |
+| Avg latency ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“ JSON compact (ns) | **18,815** | ~37,000 | ~28,000 | N/A |
+| Avg latency ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“ production preset (ns) | **28,278** | ~45,000 | ~35,000 | N/A |
 | Max observed throughput (ops/sec) | **36.48M** | ~0.18M | ~0.12M |N/A (based on implementation) |
 | Avg baseline latency (ns) | **~939** | ~25,000 | ~8,500 |N/A (based on implementation) |
 
@@ -159,9 +159,9 @@ This feature is **not available** in std.log, nexlog, or log.zig.
 7. **Production Tested**: Compression, rotation, and retention policies
 8. **Cross-Platform**: Works on Linux, macOS, Windows, and bare-metal
 9. **Multiple Compression Algorithms**: DEFLATE, GZIP, ZLIB, Zstd, LZMA, LZMA2, XZ, ZIP, TAR.GZ, LZ4 with automatic detection, factory methods, and presets
-10. **Performance Optimized** (v0.1.6+): ~7.5x faster than v0.1.5 with performance-first defaults
+10. **Performance Optimized** (v0.1.8+): ~7.5x faster than v0.1.8 with performance-first defaults
 
-## Compression Algorithm Comparison (v0.1.6+)
+## Compression Algorithm Comparison (v0.1.8+)
 
 Logly.zig supports multiple compression and archive algorithms for log archival and archiving:
 
@@ -179,7 +179,7 @@ Logly.zig supports multiple compression and archive algorithms for log archival 
 | **lz4** | 1-2x | ~600 MB/s | ~1000 MB/s | `.lz4` | Real-time, ultra-fast compression |
 
 ::: tip Recommendation
-Use **zstd** (v0.1.5+) for best performance and a great general-purpose tradeoff. For long-term archival prefer **LZMA / XZ** (higher ratio); for ultra-low-latency real-time logging prefer **LZ4** (fastest). Choose based on the speed vs ratio trade-off for your workload.
+Use **zstd** (v0.1.8+) for best performance and a great general-purpose tradeoff. For long-term archival prefer **LZMA / XZ** (higher ratio); for ultra-low-latency real-time logging prefer **LZ4** (fastest). Choose based on the speed vs ratio trade-off for your workload.
 :::
 
 ## OpenTelemetry Comparison (v0.1.4+)
@@ -188,23 +188,23 @@ Logly.zig provides comprehensive OpenTelemetry integration:
 
 | Feature | logly.zig | nexlog | log.zig | std.log |
 |:--------|:----------|:-------|:--------|:--------|
-| OpenTelemetry Support | ✅ Full | ❌ | ❌ | ❌ |
-| OTLP Export | ✅ JSON format | ❌ | ❌ | ❌ |
-| Jaeger Integration | ✅ Thrift format | ❌ | ❌ | ❌ |
-| Zipkin Integration | ✅ JSON format | ❌ | ❌ | ❌ |
-| Datadog APM | ✅ Native format | ❌ | ❌ | ❌ |
-| Google Cloud Trace | ✅ Native format | ❌ | ❌ | ❌ |
-| Google Analytics 4 | ✅ Measurement Protocol | ❌ | ❌ | ❌ |
-| AWS X-Ray | ✅ Segment format | ❌ | ❌ | ❌ |
-| Azure App Insights | ✅ Envelope format | ❌ | ❌ | ❌ |
-| W3C Trace Context | ✅ Full spec | ⚠ Partial | ❌ | ❌ |
-| W3C Baggage | ✅ Full spec | ❌ | ❌ | ❌ |
-| Span Sampling | ✅ 4 strategies | ❌ | ❌ | ❌ |
-| Metrics Export | ✅ OTLP/Prometheus/JSON | ❌ | ⚠ Prometheus | ❌ |
-| File Exporter | ✅ JSONL | ❌ | ❌ | ❌ |
-| Custom Exporters | ✅ Plugin API | ❌ | ❌ | ❌ |
+| OpenTelemetry Support | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Full | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| OTLP Export | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ JSON format | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Jaeger Integration | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Thrift format | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Zipkin Integration | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ JSON format | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Datadog APM | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Native format | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Google Cloud Trace | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Native format | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Google Analytics 4 | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Measurement Protocol | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| AWS X-Ray | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Segment format | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Azure App Insights | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Envelope format | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| W3C Trace Context | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Full spec | ÃƒÂ¢Ã…Â¡Ã‚Â  Partial | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| W3C Baggage | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Full spec | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Span Sampling | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ 4 strategies | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Metrics Export | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ OTLP/Prometheus/JSON | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…Â¡Ã‚Â  Prometheus | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| File Exporter | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ JSONL | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| Custom Exporters | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Plugin API | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
 
-**Note (v0.1.6):** Resolved a compile-time issue in the OTLP exporter (removed an unnecessary discard in `writeOtlpSpan`) and clarified span-processor behavior: `.simple` keeps completed spans pending until an explicit `exportSpans()` or `flush()` call, while `.batch` will auto-export when configured batch size or timeout thresholds are reached.
+**Note (v0.1.8):** Resolved a compile-time issue in the OTLP exporter (removed an unnecessary discard in `writeOtlpSpan`) and clarified span-processor behavior: `.simple` keeps completed spans pending until an explicit `exportSpans()` or `flush()` call, while `.batch` will auto-export when configured batch size or timeout thresholds are reached.
 
 ## Rotation Presets Comparison
 
@@ -212,11 +212,11 @@ Logly.zig offers 25+ rotation presets for common scenarios:
 
 | Category | Presets | Other Libraries |
 |:---------|:--------|:----------------|
-| **Time-Based** | `daily7Days`, `daily30Days`, `daily90Days`, `daily365Days`, `hourly24Hours`, `hourly48Hours`, `hourly7Days`, `weekly4Weeks`, `weekly12Weeks`, `monthly12Months`, `minutely60` | ❌ Manual config |
-| **Size-Based** | `size1MB`, `size5MB`, `size10MB`, `size25MB`, `size50MB`, `size100MB`, `size250MB`, `size500MB`, `size1GB` | ❌ Manual config |
-| **Hybrid** | `dailyOr100MB`, `hourlyOr50MB`, `dailyOr500MB` | ❌ Not supported |
-| **Production** | `production`, `enterprise`, `debug`, `highVolume`, `audit`, `minimal` | ❌ Not supported |
-| **Sink Helpers** | `dailySink`, `hourlySink`, `weeklySink`, `monthlySink`, `sizeSink` | ❌ Not supported |
+| **Time-Based** | `daily7Days`, `daily30Days`, `daily90Days`, `daily365Days`, `hourly24Hours`, `hourly48Hours`, `hourly7Days`, `weekly4Weeks`, `weekly12Weeks`, `monthly12Months`, `minutely60` | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual config |
+| **Size-Based** | `size1MB`, `size5MB`, `size10MB`, `size25MB`, `size50MB`, `size100MB`, `size250MB`, `size500MB`, `size1GB` | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual config |
+| **Hybrid** | `dailyOr100MB`, `hourlyOr50MB`, `dailyOr500MB` | ÃƒÂ¢Ã‚ÂÃ…â€™ Not supported |
+| **Production** | `production`, `enterprise`, `debug`, `highVolume`, `audit`, `minimal` | ÃƒÂ¢Ã‚ÂÃ…â€™ Not supported |
+| **Sink Helpers** | `dailySink`, `hourlySink`, `weeklySink`, `monthlySink`, `sizeSink` | ÃƒÂ¢Ã‚ÂÃ…â€™ Not supported |
 
 ### When to Use std.log Instead
 

--- a/docs/guide/comparison.md
+++ b/docs/guide/comparison.md
@@ -17,64 +17,64 @@ This page provides a comprehensive comparison between Logly.zig and other Zig lo
 
 | Feature | logly.zig | nexlog | log.zig | std.log |
 |:--------|:----------|:-------|:--------|:--------|
-| Current Version | 0.1.8 | 0.7.2 | 0.0.0 | Built-in |
-| Min Zig Version | 0.16.0+ | 0.14, 0.15-dev | 0.11+ | Any |
+| Current Version | 0.1.7 | 0.7.2 | 0.0.0 | Built-in |
+| Min Zig Version | 0.15.0+ | 0.14, 0.15-dev | 0.11+ | Any |
 | API Style | User-friendly | Builder/Fluent | Pool/Fluent | Basic/Manual |
-| Structured Logging | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ JSON/logfmt | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ JSON/logfmt | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual |
-| File Formats (.json, .txt, .log) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Async Logging | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic (ring buffer, workers) | ÃƒÂ¢Ã…Â¡Ã‚Â  Basic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Thread Safety | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã…Â¡Ã‚Â  Partial | ÃƒÂ¢Ã…Â¡Ã‚Â  Pool-only | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Basic |
-| Single/Multi-Thread Support | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Manual |
-| Multiple Sinks | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã…Â¡Ã‚Â  Limited | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| File Logging | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual |
-| File Rotation | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic (Time + Size) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Size | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Retention Policy | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Compression | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic (gzip/zlib/deflate/zstd, lzma, lzma2, xz, tar.gz, zip, lz4) | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Zstd Compression (v0.1.8+) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Levels 1-22, presets, batch ops | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Rotation Presets (v0.1.8+) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ 25+ presets (time/size/hybrid/production) | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Performance Defaults (v0.1.8+) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Optimized auto_flush/callbacks defaults | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Network Logging | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic (TCP/UDP) | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Stack Traces | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual |
-| Redaction (PII) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Sampling/Rate Limit | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Distributed Tracing | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic (Trace/Span/Correlation IDs) + Callbacks | ÃƒÂ¢Ã…Â¡Ã‚Â  Context only | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| OpenTelemetry (v0.1.4+) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Full OTLP/Jaeger/Zipkin/Datadog/AWS/Azure | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Metrics | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…Â¡Ã‚Â  Prometheus | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| System Diagnostics | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Filtering | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Manual |
-| Scheduled Cleaning | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Dynamic Path | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Module-level Config | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Manual |
-| Custom Log Levels | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Rules System (v0.1.0+) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Template-triggered messages | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Bare-Metal Support | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ |
-| Prebuilt Libraries | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ |
-| Documentation Site | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ |
-| Auto-Update Checker | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| CI/CodeQL | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ | ÃƒÂ¢Ã…Â¡Ã‚Â  | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ |
+| Structured Logging | ✅ Automatic | ✅ JSON/logfmt | ✅ JSON/logfmt | ❌ Manual |
+| File Formats (.json, .txt, .log) | ✅ Automatic | ✅ | ✅ | ❌ |
+| Async Logging | ✅ Automatic (ring buffer, workers) | ⚠ Basic | ❌ | ❌ |
+| Thread Safety | ✅ Automatic | ⚠ Partial | ⚠ Pool-only | ✅ Basic |
+| Single/Multi-Thread Support | ✅ | ❌ | ❌ | ✅ Manual |
+| Multiple Sinks | ✅ Automatic | ✅ | ⚠ Limited | ❌ |
+| File Logging | ✅ Automatic | ✅ | ✅ | ❌ Manual |
+| File Rotation | ✅ Automatic (Time + Size) | ✅ Size | ❌ | ❌ |
+| Retention Policy | ✅ Automatic | ❌ | ❌ | ❌ |
+| Compression | ✅ Automatic (gzip/zlib/deflate/zstd, lzma, lzma2, xz, tar.gz, zip, lz4) | ❌ | ❌ | ❌ |
+| Zstd Compression (v0.1.5+) | ✅ Levels 1-22, presets, batch ops | ❌ | ❌ | ❌ |
+| Rotation Presets (v0.1.5+) | ✅ 25+ presets (time/size/hybrid/production) | ❌ | ❌ | ❌ |
+| Performance Defaults (v0.1.6+) | ✅ Optimized auto_flush/callbacks defaults | ❌ | ❌ | ❌ |
+| Network Logging | ✅ Automatic (TCP/UDP) | ❌ | ❌ | ❌ |
+| Stack Traces | ✅ Automatic | ❌ | ❌ | ❌ Manual |
+| Redaction (PII) | ✅ Automatic | ❌ | ❌ | ❌ |
+| Sampling/Rate Limit | ✅ Automatic | ❌ | ❌ | ❌ |
+| Distributed Tracing | ✅ Automatic (Trace/Span/Correlation IDs) + Callbacks | ⚠ Context only | ❌ | ❌ |
+| OpenTelemetry (v0.1.4+) | ✅ Full OTLP/Jaeger/Zipkin/Datadog/AWS/Azure | ❌ | ❌ | ❌ |
+| Metrics | ✅ Automatic | ❌ | ⚠ Prometheus | ❌ |
+| System Diagnostics | ✅ Automatic | ❌ | ❌ | ❌ |
+| Filtering | ✅ Automatic | ❌ | ❌ | ✅ Manual |
+| Scheduled Cleaning | ✅ Automatic | ❌ | ❌ | ❌ |
+| Dynamic Path | ✅ Automatic | ❌ | ❌ | ❌ |
+| Module-level Config | ✅ | ❌ | ❌ | ✅ Manual |
+| Custom Log Levels | ✅ | ❌ | ❌ | ❌ |
+| Rules System (v0.1.0+) | ✅ Template-triggered messages | ❌ | ❌ | ❌ |
+| Bare-Metal Support | ✅ | ❌ | ❌ | ✅ |
+| Prebuilt Libraries | ✅ | ❌ | ❌ | ✅ |
+| Documentation Site | ✅ | ❌ | ❌ | ✅ |
+| Auto-Update Checker | ✅ | ❌ | ❌ | ❌ |
+| CI/CodeQL | ✅ | ⚠ | ❌ | ✅ |
 | License | MIT | MIT | MIT | MIT |
 
 ### Standard Library Comparison (Automatic vs Manual)
 
 | Feature | logly.zig | std.log | Notes |
 |:--------|:----------|:--------|:------|
-| Log Levels | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ 10 levels (trace ÃƒÂ¢Ã¢â‚¬Â Ã¢â‚¬â„¢ fatal) | 4 levels (debug, info, warn, err) | logly.zig has more granularity |
-| Custom Levels | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | Define your own levels |
-| Colored Output | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ | Cross-platform ANSI colors |
-| JSON Output | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | Built-in JSON formatter |
-| File Output | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual (stderr only) | Must implement manually for std.log |
-| Async Logging | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | Ring buffer with workers |
-| Context Binding | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | Persistent fields across logs |
-| Formatted Logging | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic templates | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Manual format strings | std.log uses basic printf-style |
-| Thread Safety | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic (advanced) | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Basic | logly.zig has lock-free options |
-| Performance Tuning | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic presets | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | Production/development presets |
-| File Rotation | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | Time + size based rotation |
-| Compression | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | gzip/zlib/zstd support |
-| Network Logging | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | TCP/UDP sinks |
-| Redaction | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | PII masking built-in |
-| Metrics | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | Built-in counters and stats |
-| Distributed Tracing | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual | Trace/span/correlation IDs |
-| Rules System | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Automatic triggers | ÃƒÂ¢Ã‚ÂÃ…â€™ | Template-based diagnostic messages |
+| Log Levels | ✅ 10 levels (trace → fatal) | 4 levels (debug, info, warn, err) | logly.zig has more granularity |
+| Custom Levels | ✅ Automatic | ❌ | Define your own levels |
+| Colored Output | ✅ Automatic | ❌ | Cross-platform ANSI colors |
+| JSON Output | ✅ Automatic | ❌ Manual | Built-in JSON formatter |
+| File Output | ✅ Automatic | ❌ Manual (stderr only) | Must implement manually for std.log |
+| Async Logging | ✅ Automatic | ❌ Manual | Ring buffer with workers |
+| Context Binding | ✅ Automatic | ❌ Manual | Persistent fields across logs |
+| Formatted Logging | ✅ Automatic templates | ✅ Manual format strings | std.log uses basic printf-style |
+| Thread Safety | ✅ Automatic (advanced) | ✅ Basic | logly.zig has lock-free options |
+| Performance Tuning | ✅ Automatic presets | ❌ Manual | Production/development presets |
+| File Rotation | ✅ Automatic | ❌ Manual | Time + size based rotation |
+| Compression | ✅ Automatic | ❌ Manual | gzip/zlib/zstd support |
+| Network Logging | ✅ Automatic | ❌ Manual | TCP/UDP sinks |
+| Redaction | ✅ Automatic | ❌ Manual | PII masking built-in |
+| Metrics | ✅ Automatic | ❌ Manual | Built-in counters and stats |
+| Distributed Tracing | ✅ Automatic | ❌ Manual | Trace/span/correlation IDs |
+| Rules System | ✅ Automatic triggers | ❌ | Template-based diagnostic messages |
 
 ::: info Automatic vs Manual
 - **Automatic**: Feature works out-of-the-box with configuration
@@ -95,9 +95,9 @@ This page provides a comprehensive comparison between Logly.zig and other Zig lo
 | Async high-throughput (ops/sec) | **36,483,035** | ~180,000 | N/A | N/A |
 | Multi-threaded (4 threads, ops/sec) | **51,211** | ~22,000 | ~18,000 | N/A (based on implementation) |
 | Multi-threaded JSON (4 threads, ops/sec) | **37,412** | ~14,000 | ~12,000 | N/A |
-| Avg latency ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“ minimal config (ns) | **8,758** | ~24,000 | ~8,000 | N/A (based on implementation) |
-| Avg latency ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“ JSON compact (ns) | **18,815** | ~37,000 | ~28,000 | N/A |
-| Avg latency ÃƒÂ¢Ã¢â€šÂ¬Ã¢â‚¬Å“ production preset (ns) | **28,278** | ~45,000 | ~35,000 | N/A |
+| Avg latency – minimal config (ns) | **8,758** | ~24,000 | ~8,000 | N/A (based on implementation) |
+| Avg latency – JSON compact (ns) | **18,815** | ~37,000 | ~28,000 | N/A |
+| Avg latency – production preset (ns) | **28,278** | ~45,000 | ~35,000 | N/A |
 | Max observed throughput (ops/sec) | **36.48M** | ~0.18M | ~0.12M |N/A (based on implementation) |
 | Avg baseline latency (ns) | **~939** | ~25,000 | ~8,500 |N/A (based on implementation) |
 
@@ -159,9 +159,9 @@ This feature is **not available** in std.log, nexlog, or log.zig.
 7. **Production Tested**: Compression, rotation, and retention policies
 8. **Cross-Platform**: Works on Linux, macOS, Windows, and bare-metal
 9. **Multiple Compression Algorithms**: DEFLATE, GZIP, ZLIB, Zstd, LZMA, LZMA2, XZ, ZIP, TAR.GZ, LZ4 with automatic detection, factory methods, and presets
-10. **Performance Optimized** (v0.1.8+): ~7.5x faster than v0.1.8 with performance-first defaults
+10. **Performance Optimized** (v0.1.6+): ~7.5x faster than v0.1.5 with performance-first defaults
 
-## Compression Algorithm Comparison (v0.1.8+)
+## Compression Algorithm Comparison (v0.1.6+)
 
 Logly.zig supports multiple compression and archive algorithms for log archival and archiving:
 
@@ -179,7 +179,7 @@ Logly.zig supports multiple compression and archive algorithms for log archival 
 | **lz4** | 1-2x | ~600 MB/s | ~1000 MB/s | `.lz4` | Real-time, ultra-fast compression |
 
 ::: tip Recommendation
-Use **zstd** (v0.1.8+) for best performance and a great general-purpose tradeoff. For long-term archival prefer **LZMA / XZ** (higher ratio); for ultra-low-latency real-time logging prefer **LZ4** (fastest). Choose based on the speed vs ratio trade-off for your workload.
+Use **zstd** (v0.1.5+) for best performance and a great general-purpose tradeoff. For long-term archival prefer **LZMA / XZ** (higher ratio); for ultra-low-latency real-time logging prefer **LZ4** (fastest). Choose based on the speed vs ratio trade-off for your workload.
 :::
 
 ## OpenTelemetry Comparison (v0.1.4+)
@@ -188,23 +188,23 @@ Logly.zig provides comprehensive OpenTelemetry integration:
 
 | Feature | logly.zig | nexlog | log.zig | std.log |
 |:--------|:----------|:-------|:--------|:--------|
-| OpenTelemetry Support | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Full | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| OTLP Export | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ JSON format | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Jaeger Integration | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Thrift format | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Zipkin Integration | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ JSON format | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Datadog APM | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Native format | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Google Cloud Trace | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Native format | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Google Analytics 4 | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Measurement Protocol | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| AWS X-Ray | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Segment format | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Azure App Insights | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Envelope format | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| W3C Trace Context | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Full spec | ÃƒÂ¢Ã…Â¡Ã‚Â  Partial | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| W3C Baggage | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Full spec | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Span Sampling | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ 4 strategies | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Metrics Export | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ OTLP/Prometheus/JSON | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã…Â¡Ã‚Â  Prometheus | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| File Exporter | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ JSONL | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
-| Custom Exporters | ÃƒÂ¢Ã…â€œÃ¢â‚¬Â¦ Plugin API | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ | ÃƒÂ¢Ã‚ÂÃ…â€™ |
+| OpenTelemetry Support | ✅ Full | ❌ | ❌ | ❌ |
+| OTLP Export | ✅ JSON format | ❌ | ❌ | ❌ |
+| Jaeger Integration | ✅ Thrift format | ❌ | ❌ | ❌ |
+| Zipkin Integration | ✅ JSON format | ❌ | ❌ | ❌ |
+| Datadog APM | ✅ Native format | ❌ | ❌ | ❌ |
+| Google Cloud Trace | ✅ Native format | ❌ | ❌ | ❌ |
+| Google Analytics 4 | ✅ Measurement Protocol | ❌ | ❌ | ❌ |
+| AWS X-Ray | ✅ Segment format | ❌ | ❌ | ❌ |
+| Azure App Insights | ✅ Envelope format | ❌ | ❌ | ❌ |
+| W3C Trace Context | ✅ Full spec | ⚠ Partial | ❌ | ❌ |
+| W3C Baggage | ✅ Full spec | ❌ | ❌ | ❌ |
+| Span Sampling | ✅ 4 strategies | ❌ | ❌ | ❌ |
+| Metrics Export | ✅ OTLP/Prometheus/JSON | ❌ | ⚠ Prometheus | ❌ |
+| File Exporter | ✅ JSONL | ❌ | ❌ | ❌ |
+| Custom Exporters | ✅ Plugin API | ❌ | ❌ | ❌ |
 
-**Note (v0.1.8):** Resolved a compile-time issue in the OTLP exporter (removed an unnecessary discard in `writeOtlpSpan`) and clarified span-processor behavior: `.simple` keeps completed spans pending until an explicit `exportSpans()` or `flush()` call, while `.batch` will auto-export when configured batch size or timeout thresholds are reached.
+**Note (v0.1.6):** Resolved a compile-time issue in the OTLP exporter (removed an unnecessary discard in `writeOtlpSpan`) and clarified span-processor behavior: `.simple` keeps completed spans pending until an explicit `exportSpans()` or `flush()` call, while `.batch` will auto-export when configured batch size or timeout thresholds are reached.
 
 ## Rotation Presets Comparison
 
@@ -212,11 +212,11 @@ Logly.zig offers 25+ rotation presets for common scenarios:
 
 | Category | Presets | Other Libraries |
 |:---------|:--------|:----------------|
-| **Time-Based** | `daily7Days`, `daily30Days`, `daily90Days`, `daily365Days`, `hourly24Hours`, `hourly48Hours`, `hourly7Days`, `weekly4Weeks`, `weekly12Weeks`, `monthly12Months`, `minutely60` | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual config |
-| **Size-Based** | `size1MB`, `size5MB`, `size10MB`, `size25MB`, `size50MB`, `size100MB`, `size250MB`, `size500MB`, `size1GB` | ÃƒÂ¢Ã‚ÂÃ…â€™ Manual config |
-| **Hybrid** | `dailyOr100MB`, `hourlyOr50MB`, `dailyOr500MB` | ÃƒÂ¢Ã‚ÂÃ…â€™ Not supported |
-| **Production** | `production`, `enterprise`, `debug`, `highVolume`, `audit`, `minimal` | ÃƒÂ¢Ã‚ÂÃ…â€™ Not supported |
-| **Sink Helpers** | `dailySink`, `hourlySink`, `weeklySink`, `monthlySink`, `sizeSink` | ÃƒÂ¢Ã‚ÂÃ…â€™ Not supported |
+| **Time-Based** | `daily7Days`, `daily30Days`, `daily90Days`, `daily365Days`, `hourly24Hours`, `hourly48Hours`, `hourly7Days`, `weekly4Weeks`, `weekly12Weeks`, `monthly12Months`, `minutely60` | ❌ Manual config |
+| **Size-Based** | `size1MB`, `size5MB`, `size10MB`, `size25MB`, `size50MB`, `size100MB`, `size250MB`, `size500MB`, `size1GB` | ❌ Manual config |
+| **Hybrid** | `dailyOr100MB`, `hourlyOr50MB`, `dailyOr500MB` | ❌ Not supported |
+| **Production** | `production`, `enterprise`, `debug`, `highVolume`, `audit`, `minimal` | ❌ Not supported |
+| **Sink Helpers** | `dailySink`, `hourlySink`, `weeklySink`, `monthlySink`, `sizeSink` | ❌ Not supported |
 
 ### When to Use std.log Instead
 

--- a/docs/guide/compression.md
+++ b/docs/guide/compression.md
@@ -31,7 +31,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -109,7 +109,7 @@ const zstd_best_cfg = CompressionConfig.zstdBest();   // Best zstd ratio
 const zstd_prod_cfg = CompressionConfig.zstdProduction(); // Production zstd
 const zstd_custom = CompressionConfig.zstdWithLevel(12); // Custom level
 
-// v0.1.6+ algorithms
+// v0.1.8+ algorithms
 const lzma_cfg = CompressionConfig.lzma();            // LZMA
 const xz_cfg = CompressionConfig.xz();                // XZ
 const lz4_cfg = CompressionConfig.lz4();              // LZ4
@@ -122,7 +122,7 @@ const size_cfg = CompressionConfig.onSize(5 * 1024 * 1024);
 // Use with Config
 var config = logly.Config.default().withCompression(prod_cfg);
 
-// Or use zstd for best performance (v0.1.5+)
+// Or use zstd for best performance (v0.1.8+)
 var zstd_config = logly.Config.default().withZstdCompression();
 ```
 
@@ -147,7 +147,7 @@ var comp15 = logly.Compression.zstdFast(allocator);          // Fast zstd
 var comp16 = logly.Compression.zstdBest(allocator);          // Best zstd ratio
 var comp17 = logly.Compression.zstdProduction(allocator);    // Production zstd
 
-// v0.1.6+ factory methods
+// v0.1.8+ factory methods
 var lzma_comp = logly.Compression.lzmaCompression(allocator);
 var xz_comp = logly.Compression.xzCompression(allocator);
 var lz4_comp = logly.Compression.lz4Compression(allocator);
@@ -158,7 +158,7 @@ defer comp1.deinit();
 // ... defer for others
 ```
 
-## Zstd Compression (v0.1.5+)
+## Zstd Compression (v0.1.8+)
 
 Zstandard (zstd) is a high-performance compression algorithm that provides excellent compression ratios with very fast decompression. It's ideal for log files, especially in production environments.
 
@@ -198,7 +198,7 @@ var config4 = logly.Config.default().withZstdProductionCompression(); // Backgro
 ### Direct Zstd Compression
 
 ```zig
-var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+var gpa = std.heap.DebugAllocator(.{}){};
 defer _ = gpa.deinit();
 const allocator = gpa.allocator();
 
@@ -234,9 +234,9 @@ const files_compressed = try compressor.compressDirectory("logs/archive/");
 std.debug.print("Compressed {d} files\n", .{files_compressed});
 ```
 
-## New Compression Algorithms (v0.1.6+)
+## New Compression Algorithms (v0.1.8+)
 
-v0.1.6 introduces full compression and decompression support for six additional algorithms, providing flexibility for different use cases.
+v0.1.8 introduces full compression and decompression support for six additional algorithms, providing flexibility for different use cases.
 
 ### Algorithm Overview
 
@@ -347,11 +347,11 @@ Customize compressed file names, locations, and archive structure:
 
 | Option | Description | Example |
 |--------|-------------|---------|
-| `file_prefix` | Prefix for file names | `"archive_"` → `archive_app.log.gz` |
-| `file_suffix` | Suffix before extension | `"_old"` → `app_old.log.gz` |
+| `file_prefix` | Prefix for file names | `"archive_"` â†’ `archive_app.log.gz` |
+| `file_suffix` | Suffix before extension | `"_old"` â†’ `app_old.log.gz` |
 | `archive_root_dir` | Centralized archive location | `"logs/archive"` |
 | `create_date_subdirs` | Create YYYY/MM/DD structure | `logs/archive/2026/01/09/` |
-| `preserve_dir_structure` | Keep original folder structure | Original: `src/logs/` → `archive/src/logs/` |
+| `preserve_dir_structure` | Keep original folder structure | Original: `src/logs/` â†’ `archive/src/logs/` |
 | `naming_pattern` | Custom naming with placeholders | `"{base}_{date}{ext}"` |
 
 ### Naming Pattern Placeholders
@@ -586,14 +586,20 @@ Use `compressStream` when you need fine-grained control, such as using existing 
 
 ```zig
 // 1. Manually create/open files
-var out_file = try std.fs.cwd().createFile("custom_output.gz", .{});
-defer out_file.close();
+const io = logly.Utils.io();
+var out_file = try std.Io.Dir.cwd().createFile(io, "custom_output.gz", .{});
+defer out_file.close(io);
 
-var in_file = try std.fs.cwd().openFile("input.log", .{});
-defer in_file.close();
+var in_file = try std.Io.Dir.cwd().openFile(io, "input.log", .{});
+defer in_file.close(io);
 
 // 2. Stream compression
-try compression.compressStream(in_file.reader(), out_file.writer());
+var in_buffer: [4096]u8 = undefined;
+var out_buffer: [4096]u8 = undefined;
+var input_reader = in_file.reader(io, &in_buffer);
+var output_writer = out_file.writer(io, &out_buffer);
+try compression.compressStream(&input_reader.interface, &output_writer.interface);
+try output_writer.interface.flush();
 ```
 
 ## Compression Modes
@@ -658,20 +664,24 @@ var stream_comp = logly.Compression.init(allocator);
 defer stream_comp.deinit();
 
 // 1. Create the output file (compressed destination)
-var file = try std.fs.cwd().createFile("data.gz", .{});
-defer file.close();
+const io = logly.Utils.io();
+var file = try std.Io.Dir.cwd().createFile(io, "data.gz", .{});
+defer file.close(io);
 
 // 2. Prepare input stream (e.g., from a network socket or another file)
 // Here we use a fixed buffer for demonstration
 const data = "Log data to be streamed..." ** 100;
-var input_stream = std.io.fixedBufferStream(data);
+var input_stream = std.Io.Reader.fixed(data);
 
 // 3. Compress directly to the file
 // The data flows: input_stream -> compressor -> file
-try stream_comp.compressStream(input_stream.reader(), file.writer());
+var file_buffer: [4096]u8 = undefined;
+var file_writer = file.writer(io, &file_buffer);
+try stream_comp.compressStream(&input_stream, &file_writer.interface);
+try file_writer.interface.flush();
 
 // 4. Verify file creation
-const stat = try file.stat();
+const stat = try std.Io.Dir.cwd().statFile(io, "data.gz");
 std.debug.print("Created data.gz: {d} bytes\n", .{stat.size});
 ```
 
@@ -1076,7 +1086,7 @@ fn onCompressionError(path: []const u8, err: anyerror) void {
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -1143,9 +1153,9 @@ for (strategies) |strategy| {
     });
     defer compression.deinit();
 
-    const start = std.time.nanoTimestamp();
+    const start = logly.Utils.currentNanos();
     const compressed = try compression.compress(test_data);
-    const elapsed = std.time.nanoTimestamp() - start;
+    const elapsed = logly.Utils.currentNanos() - start;
     defer allocator.free(compressed);
 
     const ratio = @as(f64, @floatFromInt(test_data.len)) / 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -18,15 +18,15 @@ The `Config` struct is the primary interface for global settings. You can start 
 ```zig
 var config = logly.Config.default();
 
-// 🎚️ Global controls
+// ðŸŽšï¸ Global controls
 config.global_color_display = true;
 config.global_console_display = true;
 config.global_file_storage = true;
 
-// 🔍 Log level
+// ðŸ” Log level
 config.level = .debug;
 
-// 👁️ Display options
+// ðŸ‘ï¸ Display options
 config.show_time = true;
 config.show_module = true;
 config.show_function = false;
@@ -35,12 +35,12 @@ config.show_lineno = true;   // Pinpoint the exact line
 config.include_hostname = true; // Add hostname to logs
 config.include_pid = true;      // Add process ID
 
-// 📝 Output format
+// ðŸ“ Output format
 config.json = false;
 config.pretty_json = false;
 config.color = true;
 
-// ⚡ Features
+// âš¡ Features
 config.enable_callbacks = false;  // Enable only when using callbacks
 config.enable_exception_handling = true;
 
@@ -119,10 +119,10 @@ config.telemetry = logly.TelemetryConfig.development();
 
 Notes:
 - `span_processor_type` semantics:
-  - `.simple` — Completed spans are kept pending until you explicitly call `telemetry.exportSpans()` or `telemetry.flush()`. Use this when you want to control export timing (e.g., at request boundaries).
-  - `.batch` — Spans are buffered and automatically exported when `batch_size` or `batch_timeout_ms` thresholds are reached.
+  - `.simple` â€” Completed spans are kept pending until you explicitly call `telemetry.exportSpans()` or `telemetry.flush()`. Use this when you want to control export timing (e.g., at request boundaries).
+  - `.batch` â€” Spans are buffered and automatically exported when `batch_size` or `batch_timeout_ms` thresholds are reached.
 - Default telemetry values (batch size, timeouts, headers) are centralized in `Constants.TelemetryDefaults`.
-- v0.1.6: Fixed an OTLP exporter compile-time issue (removed an unnecessary discard in `writeOtlpSpan`) so telemetry builds cleanly across targets.
+- v0.1.8: Fixed an OTLP exporter compile-time issue (removed an unnecessary discard in `writeOtlpSpan`) so telemetry builds cleanly across targets.
 
 ### Thread Pool Configuration
 
@@ -240,7 +240,7 @@ You can also run your application/request scratch allocations in your own arena 
 ```zig
 const std = @import("std");
 
-var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+var gpa = std.heap.DebugAllocator(.{}){};
 defer _ = gpa.deinit();
 
 var app_arena = std.heap.ArenaAllocator.init(gpa.allocator());
@@ -707,7 +707,7 @@ The Rules System provides guided diagnostics and can be customized with specific
 var config = logly.Config.default();
 config.rules.enabled = true;
 // Define custom symbols (supports Emoji if terminal allows)
-config.rules.symbols.error_analysis = "🛑 Cause:";
+config.rules.symbols.error_analysis = "ðŸ›‘ Cause:";
 ```
 
 ## Advanced Features

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -119,8 +119,8 @@ config.telemetry = logly.TelemetryConfig.development();
 
 Notes:
 - `span_processor_type` semantics:
-  - `.simple` â€” Completed spans are kept pending until you explicitly call `telemetry.exportSpans()` or `telemetry.flush()`. Use this when you want to control export timing (e.g., at request boundaries).
-  - `.batch` â€” Spans are buffered and automatically exported when `batch_size` or `batch_timeout_ms` thresholds are reached.
+  - `.simple`: Completed spans are kept pending until you explicitly call `telemetry.exportSpans()` or `telemetry.flush()`. Use this when you want to control export timing (e.g., at request boundaries).
+  - `.batch` : Spans are buffered and automatically exported when `batch_size` or `batch_timeout_ms` thresholds are reached.
 - Default telemetry values (batch size, timeouts, headers) are centralized in `Constants.TelemetryDefaults`.
 - v0.1.8: Fixed an OTLP exporter compile-time issue (removed an unnecessary discard in `writeOtlpSpan`) so telemetry builds cleanly across targets.
 

--- a/docs/guide/custom-levels.md
+++ b/docs/guide/custom-levels.md
@@ -99,7 +99,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/guide/customizations.md
+++ b/docs/guide/customizations.md
@@ -253,7 +253,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/guide/diagnostics.md
+++ b/docs/guide/diagnostics.md
@@ -28,7 +28,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -218,7 +218,7 @@ Track system resources in production environments:
 
 ```zig
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -340,7 +340,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -378,7 +378,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -415,7 +415,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/guide/filtering.md
+++ b/docs/guide/filtering.md
@@ -28,7 +28,7 @@ const logly = @import("logly");
 const Filter = logly.Filter;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -107,7 +107,7 @@ try filter.addMessageFilter("error", .allow);
 
 ### Regex Filtering
 
-Filter messages or modules using the improved regex-like engine (v0.1.5):
+Filter messages or modules using the improved regex-like engine (v0.1.8):
 
 ```zig
 var filter = Filter.init(allocator);
@@ -179,7 +179,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -218,7 +218,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -271,7 +271,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -317,7 +317,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -377,7 +377,7 @@ const logly = @import("logly");
 const Filter = logly.Filter;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -428,7 +428,7 @@ pub fn main() !void {
 3. **Test your filters**: Verify filtering works at different levels
 4. **Document filter rules**: Add comments explaining why each rule exists
 
-## New Features (v0.1.5)
+## New Features (v0.1.8)
 
 ### Improved Regex Engine
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -13,7 +13,7 @@ Get started with Logly.zig in minutes.
 
 ## Prerequisites
 
-- Zig 0.15.0 or higher
+- Zig 0.15.0 or Zig 0.16.0 or higher
 - Basic familiarity with Zig
 
 ## Installation
@@ -22,13 +22,19 @@ Get started with Logly.zig in minutes.
 
 The easiest way to install Logly-Zig is using the `zig fetch` command:
 
+**For Zig 0.16.0+ (Latest stable `0.1.8`):**
+
+```bash
+zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz
+```
+
+**For Zig 0.15.0 (Use `0.1.7`):**
+
 ```bash
 zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.7.tar.gz
 ```
 
-or
-
-For Nightly/PreRelease, use this command:
+**For Nightly/PreRelease:**
 
 ```bash
 zig fetch --save git+https://github.com/muhammad-fiaz/logly.zig.git
@@ -42,6 +48,23 @@ This command automatically:
 ### Method 2: Manual Installation
 
 If you prefer manual installation, add to your `build.zig.zon`:
+
+**For Zig 0.16.0+:**
+
+```zig
+.{
+    .name = "my-project",
+    .version = "0.1.0",
+    .dependencies = .{
+        .logly = .{
+            .url = "https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz",
+            .hash = "1220...", // Run: zig fetch <url> to get this hash
+        },
+    },
+}
+```
+
+**For Zig 0.15.0:**
 
 ```zig
 .{
@@ -57,6 +80,13 @@ If you prefer manual installation, add to your `build.zig.zon`:
 ```
 
 To get the hash manually, run:
+
+**For Zig 0.16.0+:**
+```bash
+zig fetch https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz
+```
+
+**For Zig 0.15.0:**
 ```bash
 zig fetch https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.7.tar.gz
 ```
@@ -149,7 +179,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -256,7 +286,7 @@ Both sets of methods are functionally identical.
 
 If you see a hash mismatch error, run:
 ```bash
-zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.7.tar.gz
+zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz
 ```
 
 ### Colors Not Displaying on Windows

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -13,18 +13,26 @@ This guide covers all available methods to install Logly.zig in your project.
 
 ## Prerequisites
 
-- **Zig 0.15.0** or higher
+- **Zig 0.15.0** or **Zig 0.16.0** or higher
 - Basic familiarity with Zig
 
 ## Method 1: Using Zig Fetch (Recommended)
 
 The easiest way to install Logly-Zig is using the `zig fetch` command:
 
+**For Zig 0.16.0+ (Latest stable `0.1.8`):**
+
+```bash
+    zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz
+```
+
+**For Zig 0.15.0 (Use `0.1.7`):**
+
 ```bash
     zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.7.tar.gz
 ```
 
-**Or for Nightly/PreRelease:**
+**For Nightly/PreRelease:**
 
 ```bash
 zig fetch --save git+https://github.com/muhammad-fiaz/logly.zig.git
@@ -38,6 +46,23 @@ This command automatically:
 ## Method 2: Manual Installation
 
 If you prefer manual installation, add to your `build.zig.zon`:
+
+**For Zig 0.16.0+:**
+
+```zig
+.{
+    .name = "my-project",
+    .version = "0.1.0",
+    .dependencies = .{
+        .logly = .{
+            .url = "https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz",
+            .hash = "1220...", // Run: zig fetch <url> to get this hash
+        },
+    },
+}
+```
+
+**For Zig 0.15.0:**
 
 ```zig
 .{
@@ -54,6 +79,12 @@ If you prefer manual installation, add to your `build.zig.zon`:
 
 To get the hash manually, run:
 
+**For Zig 0.16.0+:**
+```bash
+zig fetch https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz
+```
+
+**For Zig 0.15.0:**
 ```bash
 zig fetch https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.7.tar.gz
 ```
@@ -136,7 +167,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -193,7 +224,7 @@ error: hash mismatch
 Update the hash in your `build.zig.zon` by running:
 
 ```bash
-zig fetch https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.7.tar.gz
+zig fetch https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz
 ```
 
 ### Module Not Found

--- a/docs/guide/metrics.md
+++ b/docs/guide/metrics.md
@@ -28,7 +28,7 @@ const logly = @import("logly");
 const Metrics = logly.Metrics;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -210,7 +210,7 @@ pub fn reportMetrics(m: *Metrics) void {
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -34,7 +34,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -199,7 +199,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/guide/redaction.md
+++ b/docs/guide/redaction.md
@@ -28,7 +28,7 @@ const logly = @import("logly");
 const Redactor = logly.Redactor;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -91,7 +91,7 @@ try redactor.addPattern("secret_key", .exact, "supersecretkey123", "[HIDDEN]");
 
 ### Regex Match
 
-Use regex-like patterns for complex matching with the improved engine (v0.1.5).
+Use regex-like patterns for complex matching with the improved engine (v0.1.8).
 Supports: `*` (zero or more), `+` (one or more), `?` (optional), `.` (any char), `\d` (digit), `\w` (word char), `\s` (whitespace).
 
 ```zig
@@ -167,7 +167,7 @@ const Redactor = logly.Redactor;
 const RedactionPresets = logly.RedactionPresets;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/guide/rules.md
+++ b/docs/guide/rules.md
@@ -440,7 +440,8 @@ Export rule messages as JSON:
 var buf: std.ArrayList(u8) = .empty;
 defer buf.deinit(allocator);
 
-try rules.formatMessagesJson(&messages, buf.writer(allocator), true);  // pretty=true
+var writer = logly.Utils.ArrayListWriter.init(&buf, allocator);
+try rules.formatMessagesJson(&messages, &writer.writer, true);  // pretty=true
 std.debug.print("{s}\n", .{buf.items});
 ```
 

--- a/docs/guide/sampling.md
+++ b/docs/guide/sampling.md
@@ -28,7 +28,7 @@ const Sampler = logly.Sampler;
 const Config = logly.Config;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -187,7 +187,7 @@ const Sampler = logly.Sampler;
 const SamplerPresets = logly.SamplerPresets;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/guide/scheduler.md
+++ b/docs/guide/scheduler.md
@@ -95,7 +95,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -656,7 +656,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/guide/source-location.md
+++ b/docs/guide/source-location.md
@@ -32,7 +32,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
 
     const config = logly.Config{
@@ -96,7 +96,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
 
     const config = logly.Config{
@@ -203,7 +203,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
 
     // Base config without source location
@@ -235,7 +235,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
 
     // Full source location configuration

--- a/docs/guide/telemetry.md
+++ b/docs/guide/telemetry.md
@@ -50,7 +50,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/guide/thread-pool.md
+++ b/docs/guide/thread-pool.md
@@ -42,7 +42,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -531,7 +531,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/docs/guide/tracing.md
+++ b/docs/guide/tracing.md
@@ -70,7 +70,7 @@ For single-threaded scripts, you can set global context:
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -227,7 +227,7 @@ pub fn handleHttpRequest(
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     const allocator = gpa.allocator();
 
     var logger = try logly.Logger.init(allocator);

--- a/docs/guide/update-checker.md
+++ b/docs/guide/update-checker.md
@@ -83,12 +83,12 @@ pub fn main() !void {
 
 Newer version available:
 ```text
-info: [UPDATE] A newer release is available: v0.1.7 (current 0.1.5)
+info: [UPDATE] A newer release is available: v0.1.8 (current 0.1.6)
 ```
 
 Running a dev/nightly build:
 ```text
-info: [NIGHTLY] Running a dev/nightly build ahead of latest release: current 0.1.7, latest 0.1.5
+info: [NIGHTLY] Running a dev/nightly build ahead of latest release: current 0.1.9, latest 0.1.8
 ```
 
 ## Use Cases

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
 
     // Enable ANSI colors on Windows (no-op on Linux/macOS)
@@ -105,8 +105,8 @@ pub fn main() !void {
 - **Cross-Platform**: Works on Linux, Windows, macOS, and more
 - **Well Documented**: Comprehensive guides and API documentation
 
-::: tip 💡 Note
-Logly.zig aims to be production-ready. While this is a relatively new project and not yet widely adopted, it offers powerful features that can simplify your Zig project's logging. If you love Logly.zig, feel free to use it in your projects and give it a ⭐ on GitHub!
+::: tip ðŸ’¡ Note
+Logly.zig aims to be production-ready. While this is a relatively new project and not yet widely adopted, it offers powerful features that can simplify your Zig project's logging. If you love Logly.zig, feel free to use it in your projects and give it a â­ on GitHub!
 :::
 
 ## Installation
@@ -114,7 +114,7 @@ Logly.zig aims to be production-ready. While this is a relatively new project an
 The easiest way to add Logly to your project:
 
 ```bash
-zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.7.tar.gz
+zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz
 ```
 
 This automatically adds the dependency with the correct hash to your `build.zig.zon`.
@@ -125,5 +125,5 @@ For Nightly builds, you can use the Git URL directly:
 zig fetch --save git+https://github.com/muhammad-fiaz/logly.zig.git
 ```
 
-[Get Started →](/guide/getting-started)
+[Get Started â†’](/guide/getting-started)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -105,8 +105,8 @@ pub fn main() !void {
 - **Cross-Platform**: Works on Linux, Windows, macOS, and more
 - **Well Documented**: Comprehensive guides and API documentation
 
-::: tip ðŸ’¡ Note
-Logly.zig aims to be production-ready. While this is a relatively new project and not yet widely adopted, it offers powerful features that can simplify your Zig project's logging. If you love Logly.zig, feel free to use it in your projects and give it a â­ on GitHub!
+::: tip 💡 Note
+Logly.zig aims to be production-ready. While this is a relatively new project and not yet widely adopted, it offers powerful features that can simplify your Zig project's logging. If you love Logly.zig, feel free to use it in your projects and give it a ⭐ on GitHub!
 :::
 
 ## Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -125,5 +125,5 @@ For Nightly builds, you can use the Git URL directly:
 zig fetch --save git+https://github.com/muhammad-fiaz/logly.zig.git
 ```
 
-[Get Started â†’](/guide/getting-started)
+[Get Started](/guide/getting-started)
 

--- a/examples/advanced_config.zig
+++ b/examples/advanced_config.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/advanced_features.zig
+++ b/examples/advanced_features.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/allocator_strategies.zig
+++ b/examples/allocator_strategies.zig
@@ -45,7 +45,7 @@ fn runArenaAllocatorAliasExample(allocator: std.mem.Allocator) !void {
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/async_advanced.zig
+++ b/examples/async_advanced.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -59,7 +59,7 @@ pub fn main() !void {
     // Push some entries
     for (0..10) |i| {
         _ = rb.push(.{
-            .timestamp = std.time.milliTimestamp(),
+            .timestamp = logly.Utils.currentMillis(),
             .formatted_message = "Test message",
             .level_priority = 20,
             .queued_at = @intCast(i),

--- a/examples/async_logging.zig
+++ b/examples/async_logging.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -26,13 +26,13 @@ pub fn main() !void {
     try logger.info("Starting async logging test...", @src());
 
     // Log many messages quickly
-    const start = std.time.milliTimestamp();
+    const start = logly.Utils.currentMillis();
     for (0..1000) |i| {
         const msg = try std.fmt.allocPrint(allocator, "Async log message #{d}", .{i});
         defer allocator.free(msg);
         try logger.info(msg, @src());
     }
-    const end = std.time.milliTimestamp();
+    const end = logly.Utils.currentMillis();
 
     try logger.info("Finished logging 1000 messages", @src());
 

--- a/examples/basic.zig
+++ b/examples/basic.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/callbacks.zig
+++ b/examples/callbacks.zig
@@ -8,7 +8,7 @@ fn logCallback(record: *const logly.Record) !void {
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/color_options.zig
+++ b/examples/color_options.zig
@@ -4,7 +4,7 @@ const Config = logly.Config;
 const SinkConfig = logly.SinkConfig;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/compression.zig
+++ b/examples/compression.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -25,7 +25,7 @@ pub fn main() !void {
     const decompressed = try comp.decompress(compressed);
     defer allocator.free(decompressed);
     std.debug.print("   Decompressed size: {d} bytes\n", .{decompressed.len});
-    std.debug.print("   Data integrity: {s}\n\n", .{if (std.mem.eql(u8, test_data, decompressed)) "✓ Verified" else "✗ Failed"});
+    std.debug.print("   Data integrity: {s}\n\n", .{if (std.mem.eql(u8, test_data, decompressed)) "âœ“ Verified" else "âœ— Failed"});
 
     // Example 2: Using compression presets
     std.debug.print("2. Compression Presets\n", .{});
@@ -115,8 +115,8 @@ pub fn main() !void {
 
     std.debug.print("   GZIP compressed size: {d} bytes\n\n", .{gzip_compressed.len});
 
-    // Example 7: Zstd Compression (v0.1.5+)
-    std.debug.print("7. Zstd Compression (v0.1.5+)\n", .{});
+    // Example 7: Zstd Compression (v0.1.8+)
+    std.debug.print("7. Zstd Compression (v0.1.8+)\n", .{});
     std.debug.print("   ---------------------------\n", .{});
 
     var zstd_comp = logly.Compression.zstdCompression(allocator);
@@ -132,7 +132,7 @@ pub fn main() !void {
     const zstd_decompressed = try zstd_comp.decompress(zstd_compressed);
     defer allocator.free(zstd_decompressed);
     std.debug.print("   Zstd decompressed: {d} bytes\n", .{zstd_decompressed.len});
-    std.debug.print("   Data integrity: {s}\n", .{if (std.mem.eql(u8, zstd_data, zstd_decompressed)) "✓ Verified" else "✗ Failed"});
+    std.debug.print("   Data integrity: {s}\n", .{if (std.mem.eql(u8, zstd_data, zstd_decompressed)) "âœ“ Verified" else "âœ— Failed"});
 
     // Show zstd preset options
     std.debug.print("   Zstd presets available:\n", .{});
@@ -142,8 +142,8 @@ pub fn main() !void {
     std.debug.print("     - zstdProduction(): Background + checksums\n", .{});
     std.debug.print("     - zstdWithLevel(N): Custom level (1-22)\n\n", .{});
 
-    // Example 8: Zstd Custom Levels (v0.1.5+)
-    std.debug.print("8. Zstd Custom Levels (v0.1.5+)\n", .{});
+    // Example 8: Zstd Custom Levels (v0.1.8+)
+    std.debug.print("8. Zstd Custom Levels (v0.1.8+)\n", .{});
     std.debug.print("   ----------------------------\n", .{});
 
     // Test custom zstd level 15
@@ -168,8 +168,8 @@ pub fn main() !void {
     std.debug.print("     Level 19 (best):    Best ratio, slowest\n", .{});
     std.debug.print("     Level 22 (ultra):   Maximum compression\n\n", .{});
 
-    // Example 9: Zstd Config Presets (v0.1.5+)
-    std.debug.print("9. Zstd Config Presets (v0.1.5+)\n", .{});
+    // Example 9: Zstd Config Presets (v0.1.8+)
+    std.debug.print("9. Zstd Config Presets (v0.1.8+)\n", .{});
     std.debug.print("   -----------------------------\n", .{});
 
     const zstd_config = logly.Config.CompressionConfig.zstd();
@@ -184,8 +184,8 @@ pub fn main() !void {
     std.debug.print("     Background: {s}\n", .{if (zstd_prod.background) "enabled" else "disabled"});
     std.debug.print("     Keep original: {s}\n\n", .{if (zstd_prod.keep_original) "yes" else "no"});
 
-    // Example 10: Compression Aliases (v0.1.5+)
-    std.debug.print("10. Compression Aliases (v0.1.5+)\n", .{});
+    // Example 10: Compression Aliases (v0.1.8+)
+    std.debug.print("10. Compression Aliases (v0.1.8+)\n", .{});
     std.debug.print("    ------------------------------\n", .{});
 
     var alias_comp = logly.Compression.create(allocator); // Alias for init()
@@ -198,14 +198,14 @@ pub fn main() !void {
     defer allocator.free(encoded);
     const decoded = try alias_comp.decode(encoded);
     defer allocator.free(decoded);
-    std.debug.print("    encode/decode aliases: {s}\n", .{if (std.mem.eql(u8, alias_data, decoded)) "✓ Working" else "✗ Failed"});
+    std.debug.print("    encode/decode aliases: {s}\n", .{if (std.mem.eql(u8, alias_data, decoded)) "âœ“ Working" else "âœ— Failed"});
 
     // Use deflate/inflate aliases
     const deflated = try alias_comp.deflate(alias_data);
     defer allocator.free(deflated);
     const inflated = try alias_comp.inflate(deflated);
     defer allocator.free(inflated);
-    std.debug.print("    deflate/inflate aliases: {s}\n", .{if (std.mem.eql(u8, alias_data, inflated)) "✓ Working" else "✗ Failed"});
+    std.debug.print("    deflate/inflate aliases: {s}\n", .{if (std.mem.eql(u8, alias_data, inflated)) "âœ“ Working" else "âœ— Failed"});
 
     // Check needsCompression alias
     const needs = alias_comp.needsCompression("test.log");
@@ -221,19 +221,21 @@ pub fn main() !void {
     defer stream_comp.deinit();
 
     const stream_data = "Data to be compressed via stream" ** 5;
-    var input_stream = std.io.fixedBufferStream(stream_data);
+    var input_reader = std.Io.Reader.fixed(stream_data);
     var output_buffer: std.ArrayList(u8) = .empty;
     defer output_buffer.deinit(allocator);
 
-    try stream_comp.compressStream(input_stream.reader(), output_buffer.writer(allocator));
+    var output_writer = logly.Utils.ArrayListWriter.init(&output_buffer, allocator);
+    try stream_comp.compressStream(&input_reader, &output_writer.writer);
     std.debug.print("    Stream compressed size: {d} bytes\n", .{output_buffer.items.len});
 
-    var decomp_input = std.io.fixedBufferStream(output_buffer.items);
+    var decomp_input = std.Io.Reader.fixed(output_buffer.items);
     var decomp_output: std.ArrayList(u8) = .empty;
     defer decomp_output.deinit(allocator);
 
-    try stream_comp.decompressStream(decomp_input.reader(), decomp_output.writer(allocator));
-    std.debug.print("    Stream decompressed verified: {s}\n\n", .{if (std.mem.eql(u8, stream_data, decomp_output.items)) "✓ Yes" else "✗ No"});
+    var decomp_writer = logly.Utils.ArrayListWriter.init(&decomp_output, allocator);
+    try stream_comp.decompressStream(&decomp_input, &decomp_writer.writer);
+    std.debug.print("    Stream decompressed verified: {s}\n\n", .{if (std.mem.eql(u8, stream_data, decomp_output.items)) "âœ“ Yes" else "âœ— No"});
 
     // Example 12: Directory Compression
     std.debug.print("12. Directory Compression\n", .{});
@@ -241,19 +243,20 @@ pub fn main() !void {
 
     // Create dummy logs for directory compression test
     const test_dir = "logs_test_batch";
-    std.fs.cwd().makePath(test_dir) catch {};
+    const io = logly.Utils.io();
+    std.Io.Dir.cwd().createDirPath(io, test_dir) catch {};
     // defer {
     //    // Cleanup compressed files
     //    std.fs.cwd().deleteTree(test_dir) catch {};
     // }
 
-    const log1 = try std.fs.cwd().createFile(test_dir ++ "/app.log", .{});
-    try log1.writeAll("Application log data 1");
-    log1.close();
+    const log1 = try std.Io.Dir.cwd().createFile(io, test_dir ++ "/app.log", .{});
+    defer log1.close(io);
+    try log1.writeStreamingAll(io, "Application log data 1");
 
-    const log2 = try std.fs.cwd().createFile(test_dir ++ "/error.log", .{});
-    try log2.writeAll("Error log data 2");
-    log2.close();
+    const log2 = try std.Io.Dir.cwd().createFile(io, test_dir ++ "/error.log", .{});
+    defer log2.close(io);
+    try log2.writeStreamingAll(io, "Error log data 2");
 
     var batch_comp = logly.Compression.init(allocator);
     defer batch_comp.deinit();
@@ -261,11 +264,11 @@ pub fn main() !void {
     const files_processed = try batch_comp.compressDirectory(test_dir);
     std.debug.print("    Batch compressed {d} files in '{s}'\n\n", .{ files_processed, test_dir });
 
-    // Example 13: v0.1.6 New Algorithms
-    std.debug.print("13. New Algorithms (v0.1.6+)\n", .{});
+    // Example 13: v0.1.8 New Algorithms
+    std.debug.print("13. New Algorithms (v0.1.8+)\n", .{});
     std.debug.print("    ------------------------\n", .{});
 
-    const algo_test_data = "Testing new v0.1.6 compression algorithms " ** 30;
+    const algo_test_data = "Testing new v0.1.8 compression algorithms " ** 30;
 
     // LZMA
     {
@@ -275,7 +278,7 @@ pub fn main() !void {
         defer allocator.free(lzma_compressed);
         const lzma_decompressed = try lzma_comp.decompress(lzma_compressed);
         defer allocator.free(lzma_decompressed);
-        std.debug.print("    LZMA:   {} -> {} bytes ({s})\n", .{ algo_test_data.len, lzma_compressed.len, if (std.mem.eql(u8, algo_test_data, lzma_decompressed)) "✓" else "✗" });
+        std.debug.print("    LZMA:   {} -> {} bytes ({s})\n", .{ algo_test_data.len, lzma_compressed.len, if (std.mem.eql(u8, algo_test_data, lzma_decompressed)) "âœ“" else "âœ—" });
     }
 
     // LZMA2
@@ -286,7 +289,7 @@ pub fn main() !void {
         defer allocator.free(lzma2_compressed);
         const lzma2_decompressed = try lzma2_comp.decompress(lzma2_compressed);
         defer allocator.free(lzma2_decompressed);
-        std.debug.print("    LZMA2:  {} -> {} bytes ({s})\n", .{ algo_test_data.len, lzma2_compressed.len, if (std.mem.eql(u8, algo_test_data, lzma2_decompressed)) "✓" else "✗" });
+        std.debug.print("    LZMA2:  {} -> {} bytes ({s})\n", .{ algo_test_data.len, lzma2_compressed.len, if (std.mem.eql(u8, algo_test_data, lzma2_decompressed)) "âœ“" else "âœ—" });
     }
 
     // XZ
@@ -297,7 +300,7 @@ pub fn main() !void {
         defer allocator.free(xz_compressed);
         const xz_decompressed = try xz_comp.decompress(xz_compressed);
         defer allocator.free(xz_decompressed);
-        std.debug.print("    XZ:     {} -> {} bytes ({s})\n", .{ algo_test_data.len, xz_compressed.len, if (std.mem.eql(u8, algo_test_data, xz_decompressed)) "✓" else "✗" });
+        std.debug.print("    XZ:     {} -> {} bytes ({s})\n", .{ algo_test_data.len, xz_compressed.len, if (std.mem.eql(u8, algo_test_data, xz_decompressed)) "âœ“" else "âœ—" });
     }
 
     // ZIP
@@ -308,7 +311,7 @@ pub fn main() !void {
         defer allocator.free(zip_compressed);
         const zip_decompressed = try zip_comp.decompress(zip_compressed);
         defer allocator.free(zip_decompressed);
-        std.debug.print("    ZIP:    {} -> {} bytes ({s})\n", .{ algo_test_data.len, zip_compressed.len, if (std.mem.eql(u8, algo_test_data, zip_decompressed)) "✓" else "✗" });
+        std.debug.print("    ZIP:    {} -> {} bytes ({s})\n", .{ algo_test_data.len, zip_compressed.len, if (std.mem.eql(u8, algo_test_data, zip_decompressed)) "âœ“" else "âœ—" });
     }
 
     // TAR.GZ
@@ -319,7 +322,7 @@ pub fn main() !void {
         defer allocator.free(targz_compressed);
         const targz_decompressed = try targz_comp.decompress(targz_compressed);
         defer allocator.free(targz_decompressed);
-        std.debug.print("    TAR.GZ: {} -> {} bytes ({s})\n", .{ algo_test_data.len, targz_compressed.len, if (std.mem.eql(u8, algo_test_data, targz_decompressed)) "✓" else "✗" });
+        std.debug.print("    TAR.GZ: {} -> {} bytes ({s})\n", .{ algo_test_data.len, targz_compressed.len, if (std.mem.eql(u8, algo_test_data, targz_decompressed)) "âœ“" else "âœ—" });
     }
 
     // LZ4
@@ -330,13 +333,13 @@ pub fn main() !void {
         defer allocator.free(lz4_compressed);
         const lz4_decompressed = try lz4_comp.decompress(lz4_compressed);
         defer allocator.free(lz4_decompressed);
-        std.debug.print("    LZ4:    {} -> {} bytes ({s})\n", .{ algo_test_data.len, lz4_compressed.len, if (std.mem.eql(u8, algo_test_data, lz4_decompressed)) "✓" else "✗" });
+        std.debug.print("    LZ4:    {} -> {} bytes ({s})\n", .{ algo_test_data.len, lz4_compressed.len, if (std.mem.eql(u8, algo_test_data, lz4_decompressed)) "âœ“" else "âœ—" });
     }
 
     std.debug.print("\n", .{});
 
-    // Example 14: Config Presets for v0.1.6 Algorithms
-    std.debug.print("14. Config Presets (v0.1.6+)\n", .{});
+    // Example 14: Config Presets for v0.1.8 Algorithms
+    std.debug.print("14. Config Presets (v0.1.8+)\n", .{});
     std.debug.print("    ------------------------\n", .{});
 
     const lzma_cfg = logly.Config.CompressionConfig.lzma();

--- a/examples/compression.zig
+++ b/examples/compression.zig
@@ -25,7 +25,7 @@ pub fn main() !void {
     const decompressed = try comp.decompress(compressed);
     defer allocator.free(decompressed);
     std.debug.print("   Decompressed size: {d} bytes\n", .{decompressed.len});
-    std.debug.print("   Data integrity: {s}\n\n", .{if (std.mem.eql(u8, test_data, decompressed)) "âœ“ Verified" else "âœ— Failed"});
+    std.debug.print("   Data integrity: {s}\n\n", .{if (std.mem.eql(u8, test_data, decompressed)) "✓ Verified" else "✗ Failed"});
 
     // Example 2: Using compression presets
     std.debug.print("2. Compression Presets\n", .{});
@@ -132,7 +132,7 @@ pub fn main() !void {
     const zstd_decompressed = try zstd_comp.decompress(zstd_compressed);
     defer allocator.free(zstd_decompressed);
     std.debug.print("   Zstd decompressed: {d} bytes\n", .{zstd_decompressed.len});
-    std.debug.print("   Data integrity: {s}\n", .{if (std.mem.eql(u8, zstd_data, zstd_decompressed)) "âœ“ Verified" else "âœ— Failed"});
+    std.debug.print("   Data integrity: {s}\n", .{if (std.mem.eql(u8, zstd_data, zstd_decompressed)) "✓ Verified" else "✗ Failed"});
 
     // Show zstd preset options
     std.debug.print("   Zstd presets available:\n", .{});
@@ -198,14 +198,14 @@ pub fn main() !void {
     defer allocator.free(encoded);
     const decoded = try alias_comp.decode(encoded);
     defer allocator.free(decoded);
-    std.debug.print("    encode/decode aliases: {s}\n", .{if (std.mem.eql(u8, alias_data, decoded)) "âœ“ Working" else "âœ— Failed"});
+    std.debug.print("    encode/decode aliases: {s}\n", .{if (std.mem.eql(u8, alias_data, decoded)) "✓ Working" else "✗ Failed"});
 
     // Use deflate/inflate aliases
     const deflated = try alias_comp.deflate(alias_data);
     defer allocator.free(deflated);
     const inflated = try alias_comp.inflate(deflated);
     defer allocator.free(inflated);
-    std.debug.print("    deflate/inflate aliases: {s}\n", .{if (std.mem.eql(u8, alias_data, inflated)) "âœ“ Working" else "âœ— Failed"});
+    std.debug.print("    deflate/inflate aliases: {s}\n", .{if (std.mem.eql(u8, alias_data, inflated)) "✓ Working" else "✗ Failed"});
 
     // Check needsCompression alias
     const needs = alias_comp.needsCompression("test.log");
@@ -235,7 +235,7 @@ pub fn main() !void {
 
     var decomp_writer = logly.Utils.ArrayListWriter.init(&decomp_output, allocator);
     try stream_comp.decompressStream(&decomp_input, &decomp_writer.writer);
-    std.debug.print("    Stream decompressed verified: {s}\n\n", .{if (std.mem.eql(u8, stream_data, decomp_output.items)) "âœ“ Yes" else "âœ— No"});
+    std.debug.print("    Stream decompressed verified: {s}\n\n", .{if (std.mem.eql(u8, stream_data, decomp_output.items)) "✓ Yes" else "✗ No"});
 
     // Example 12: Directory Compression
     std.debug.print("12. Directory Compression\n", .{});
@@ -278,7 +278,7 @@ pub fn main() !void {
         defer allocator.free(lzma_compressed);
         const lzma_decompressed = try lzma_comp.decompress(lzma_compressed);
         defer allocator.free(lzma_decompressed);
-        std.debug.print("    LZMA:   {} -> {} bytes ({s})\n", .{ algo_test_data.len, lzma_compressed.len, if (std.mem.eql(u8, algo_test_data, lzma_decompressed)) "âœ“" else "âœ—" });
+        std.debug.print("    LZMA:   {} -> {} bytes ({s})\n", .{ algo_test_data.len, lzma_compressed.len, if (std.mem.eql(u8, algo_test_data, lzma_decompressed)) "✓" else "✗" });
     }
 
     // LZMA2
@@ -289,7 +289,7 @@ pub fn main() !void {
         defer allocator.free(lzma2_compressed);
         const lzma2_decompressed = try lzma2_comp.decompress(lzma2_compressed);
         defer allocator.free(lzma2_decompressed);
-        std.debug.print("    LZMA2:  {} -> {} bytes ({s})\n", .{ algo_test_data.len, lzma2_compressed.len, if (std.mem.eql(u8, algo_test_data, lzma2_decompressed)) "âœ“" else "âœ—" });
+        std.debug.print("    LZMA2:  {} -> {} bytes ({s})\n", .{ algo_test_data.len, lzma2_compressed.len, if (std.mem.eql(u8, algo_test_data, lzma2_decompressed)) "✓" else "✗" });
     }
 
     // XZ
@@ -300,7 +300,7 @@ pub fn main() !void {
         defer allocator.free(xz_compressed);
         const xz_decompressed = try xz_comp.decompress(xz_compressed);
         defer allocator.free(xz_decompressed);
-        std.debug.print("    XZ:     {} -> {} bytes ({s})\n", .{ algo_test_data.len, xz_compressed.len, if (std.mem.eql(u8, algo_test_data, xz_decompressed)) "âœ“" else "âœ—" });
+        std.debug.print("    XZ:     {} -> {} bytes ({s})\n", .{ algo_test_data.len, xz_compressed.len, if (std.mem.eql(u8, algo_test_data, xz_decompressed)) "✓" else "✗" });
     }
 
     // ZIP
@@ -311,7 +311,7 @@ pub fn main() !void {
         defer allocator.free(zip_compressed);
         const zip_decompressed = try zip_comp.decompress(zip_compressed);
         defer allocator.free(zip_decompressed);
-        std.debug.print("    ZIP:    {} -> {} bytes ({s})\n", .{ algo_test_data.len, zip_compressed.len, if (std.mem.eql(u8, algo_test_data, zip_decompressed)) "âœ“" else "âœ—" });
+        std.debug.print("    ZIP:    {} -> {} bytes ({s})\n", .{ algo_test_data.len, zip_compressed.len, if (std.mem.eql(u8, algo_test_data, zip_decompressed)) "✓" else "✗" });
     }
 
     // TAR.GZ
@@ -322,7 +322,7 @@ pub fn main() !void {
         defer allocator.free(targz_compressed);
         const targz_decompressed = try targz_comp.decompress(targz_compressed);
         defer allocator.free(targz_decompressed);
-        std.debug.print("    TAR.GZ: {} -> {} bytes ({s})\n", .{ algo_test_data.len, targz_compressed.len, if (std.mem.eql(u8, algo_test_data, targz_decompressed)) "âœ“" else "âœ—" });
+        std.debug.print("    TAR.GZ: {} -> {} bytes ({s})\n", .{ algo_test_data.len, targz_compressed.len, if (std.mem.eql(u8, algo_test_data, targz_decompressed)) "✓" else "✗" });
     }
 
     // LZ4
@@ -333,7 +333,7 @@ pub fn main() !void {
         defer allocator.free(lz4_compressed);
         const lz4_decompressed = try lz4_comp.decompress(lz4_compressed);
         defer allocator.free(lz4_decompressed);
-        std.debug.print("    LZ4:    {} -> {} bytes ({s})\n", .{ algo_test_data.len, lz4_compressed.len, if (std.mem.eql(u8, algo_test_data, lz4_decompressed)) "âœ“" else "âœ—" });
+        std.debug.print("    LZ4:    {} -> {} bytes ({s})\n", .{ algo_test_data.len, lz4_compressed.len, if (std.mem.eql(u8, algo_test_data, lz4_decompressed)) "✓" else "✗" });
     }
 
     std.debug.print("\n", .{});

--- a/examples/compression_demo.zig
+++ b/examples/compression_demo.zig
@@ -4,21 +4,22 @@ const logly = @import("logly");
 const Compression = logly.Compression;
 const CompressionPresets = logly.CompressionPresets;
 
-/// Comprehensive compression demo for Logly v0.1.6
+/// Comprehensive compression demo for Logly v0.1.8
 /// Demonstrates all compression algorithms: deflate, gzip, zlib, zstd, lzma, lzma2, xz, zip, tar.gz, lz4
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
     std.debug.print("\n", .{});
     std.debug.print("=" ** 70 ++ "\n", .{});
-    std.debug.print("  Logly Compression Demo v0.1.6\n", .{});
+    std.debug.print("  Logly Compression Demo v0.1.8\n", .{});
     std.debug.print("  All Compression Algorithms: deflate, gzip, zstd, lzma, xz, zip, tar.gz, lz4\n", .{});
     std.debug.print("=" ** 70 ++ "\n\n", .{});
 
     const log_dir = "logs";
-    std.fs.cwd().makePath(log_dir) catch {};
+    const io = logly.Utils.io();
+    std.Io.Dir.cwd().createDirPath(io, log_dir) catch {};
 
     // Create sample log data
     const sample_log =
@@ -54,7 +55,7 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
     }
 
     // =========================================================================
@@ -76,13 +77,13 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
     }
 
     // =========================================================================
     // Test 3: ZSTD
     // =========================================================================
-    std.debug.print("Test 3: ZSTD Compression (v0.1.5+)\n", .{});
+    std.debug.print("Test 3: ZSTD Compression (v0.1.8+)\n", .{});
     std.debug.print("-" ** 50 ++ "\n", .{});
     {
         var comp = Compression.zstdCompression(allocator);
@@ -98,13 +99,13 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
     }
 
     // =========================================================================
-    // Test 4: LZMA (v0.1.6+)
+    // Test 4: LZMA (v0.1.8+)
     // =========================================================================
-    std.debug.print("Test 4: LZMA Compression (v0.1.6+)\n", .{});
+    std.debug.print("Test 4: LZMA Compression (v0.1.8+)\n", .{});
     std.debug.print("-" ** 50 ++ "\n", .{});
     {
         var comp = Compression.lzmaCompression(allocator);
@@ -120,13 +121,13 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
     }
 
     // =========================================================================
-    // Test 5: LZMA2 (v0.1.6+)
+    // Test 5: LZMA2 (v0.1.8+)
     // =========================================================================
-    std.debug.print("Test 5: LZMA2 Compression (v0.1.6+)\n", .{});
+    std.debug.print("Test 5: LZMA2 Compression (v0.1.8+)\n", .{});
     std.debug.print("-" ** 50 ++ "\n", .{});
     {
         var comp = Compression.lzma2Compression(allocator);
@@ -142,13 +143,13 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
     }
 
     // =========================================================================
-    // Test 6: XZ (v0.1.6+)
+    // Test 6: XZ (v0.1.8+)
     // =========================================================================
-    std.debug.print("Test 6: XZ Compression (v0.1.6+)\n", .{});
+    std.debug.print("Test 6: XZ Compression (v0.1.8+)\n", .{});
     std.debug.print("-" ** 50 ++ "\n", .{});
     {
         var comp = Compression.xzCompression(allocator);
@@ -164,13 +165,13 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
     }
 
     // =========================================================================
-    // Test 7: ZIP (v0.1.6+)
+    // Test 7: ZIP (v0.1.8+)
     // =========================================================================
-    std.debug.print("Test 7: ZIP Compression (v0.1.6+)\n", .{});
+    std.debug.print("Test 7: ZIP Compression (v0.1.8+)\n", .{});
     std.debug.print("-" ** 50 ++ "\n", .{});
     {
         var comp = Compression.zipCompression(allocator);
@@ -186,13 +187,13 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
     }
 
     // =========================================================================
-    // Test 8: TAR.GZ (v0.1.6+)
+    // Test 8: TAR.GZ (v0.1.8+)
     // =========================================================================
-    std.debug.print("Test 8: TAR.GZ Compression (v0.1.6+)\n", .{});
+    std.debug.print("Test 8: TAR.GZ Compression (v0.1.8+)\n", .{});
     std.debug.print("-" ** 50 ++ "\n", .{});
     {
         var comp = Compression.tarGzCompression(allocator);
@@ -208,13 +209,13 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
     }
 
     // =========================================================================
-    // Test 9: LZ4 (v0.1.6+)
+    // Test 9: LZ4 (v0.1.8+)
     // =========================================================================
-    std.debug.print("Test 9: LZ4 Compression (v0.1.6+)\n", .{});
+    std.debug.print("Test 9: LZ4 Compression (v0.1.8+)\n", .{});
     std.debug.print("-" ** 50 ++ "\n", .{});
     {
         var comp = Compression.lz4Compression(allocator);
@@ -230,7 +231,7 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
     }
 
     // =========================================================================
@@ -242,9 +243,9 @@ pub fn main() !void {
     // Create log file
     const log_file_path = log_dir ++ "/app.log";
     {
-        const f = try std.fs.cwd().createFile(log_file_path, .{});
-        defer f.close();
-        try f.writeAll(sample_log);
+        const f = try std.Io.Dir.cwd().createFile(io, log_file_path, .{});
+        defer f.close(io);
+        try f.writeStreamingAll(io, sample_log);
     }
     std.debug.print("  Created: {s} ({} bytes)\n", .{ log_file_path, sample_log.len });
 
@@ -262,9 +263,9 @@ pub fn main() !void {
     for (algorithms) |algo| {
         // Re-create log file for each algorithm since some might delete it
         {
-            const f = try std.fs.cwd().createFile(log_file_path, .{});
-            try f.writeAll(sample_log);
-            f.close();
+            const f = try std.Io.Dir.cwd().createFile(io, log_file_path, .{});
+            defer f.close(io);
+            try f.writeStreamingAll(io, sample_log);
         }
 
         var comp = algo.factory(allocator);

--- a/examples/compression_demo.zig
+++ b/examples/compression_demo.zig
@@ -55,7 +55,7 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
     }
 
     // =========================================================================
@@ -77,7 +77,7 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
     }
 
     // =========================================================================
@@ -99,7 +99,7 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
     }
 
     // =========================================================================
@@ -121,7 +121,7 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
     }
 
     // =========================================================================
@@ -143,7 +143,7 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
     }
 
     // =========================================================================
@@ -165,7 +165,7 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
     }
 
     // =========================================================================
@@ -187,7 +187,7 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
     }
 
     // =========================================================================
@@ -209,7 +209,7 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
     }
 
     // =========================================================================
@@ -231,7 +231,7 @@ pub fn main() !void {
         std.debug.print("  Original:    {} bytes\n", .{sample_log.len});
         std.debug.print("  Compressed:  {} bytes\n", .{compressed.len});
         std.debug.print("  Saved:       {d:.1}%\n", .{ratio});
-        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "âœ“ OK" else "âœ— FAILED"});
+        std.debug.print("  Roundtrip:   {s}\n\n", .{if (std.mem.eql(u8, sample_log, decompressed)) "✓ OK" else "✗ FAILED"});
     }
 
     // =========================================================================

--- a/examples/compression_minimal.zig
+++ b/examples/compression_minimal.zig
@@ -6,7 +6,7 @@ const Config = logly.Config;
 const CompressionConfig = Config.CompressionConfig;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/config_presets.zig
+++ b/examples/config_presets.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/context.zig
+++ b/examples/context.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/custom_colors.zig
+++ b/examples/custom_colors.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -12,7 +12,7 @@ pub fn main() !void {
     const logger = try logly.Logger.init(allocator);
     defer logger.deinit();
 
-    std.debug.print("=== Color System Demo (v0.1.5) ===\n\n", .{});
+    std.debug.print("=== Color System Demo (v0.1.8) ===\n\n", .{});
 
     // Basic custom levels with ANSI codes
     try logger.addCustomLevel("NOTICE", 22, "36;1");
@@ -50,7 +50,7 @@ pub fn main() !void {
     try logger.custom("ALERT", "Alert (Red Underline)", @src());
     try logger.custom("HIGHLIGHT", "Highlight (Yellow Bold Reverse)", @src());
 
-    std.debug.print("\n=== Level Color Variants (v0.1.5) ===\n\n", .{});
+    std.debug.print("\n=== Level Color Variants (v0.1.8) ===\n\n", .{});
 
     // Demonstrate color variants available on each level
     const Level = logly.Level;
@@ -124,7 +124,7 @@ pub fn main() !void {
     std.debug.print("  trace={s} debug={s} info={s}\n", .{ neon.trace, neon.debug, neon.info });
     std.debug.print("  success={s} warning={s} err={s}\n", .{ neon.success, neon.warning, neon.err });
 
-    std.debug.print("\n=== Advanced CustomLevel (v0.1.5) ===\n\n", .{});
+    std.debug.print("\n=== Advanced CustomLevel (v0.1.8) ===\n\n", .{});
 
     // Demonstrate advanced CustomLevel creation
     const CustomLevel = logly.CustomLevel;

--- a/examples/custom_levels_full.zig
+++ b/examples/custom_levels_full.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/custom_theme.zig
+++ b/examples/custom_theme.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -14,7 +14,7 @@ pub fn main() !void {
 
     const Theme = logly.Formatter.Theme;
 
-    std.debug.print("\n=== Theme Presets (v0.1.5) ===\n\n", .{});
+    std.debug.print("\n=== Theme Presets (v0.1.8) ===\n\n", .{});
 
     // Built-in theme presets
     std.debug.print("Available presets:\n", .{});

--- a/examples/customizations.zig
+++ b/examples/customizations.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/diagnostics.zig
+++ b/examples/diagnostics.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/distributed_json.zig
+++ b/examples/distributed_json.zig
@@ -3,7 +3,7 @@ const logly = @import("logly");
 const Config = logly.Config;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/dynamic_path.zig
+++ b/examples/dynamic_path.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/file_logging.zig
+++ b/examples/file_logging.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/filtering.zig
+++ b/examples/filtering.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 // this will help u understand filtering in logly.zig :)
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/formatted_logging.zig
+++ b/examples/formatted_logging.zig
@@ -5,7 +5,7 @@ pub fn main() !void {
     // Enable ANSI colors on Windows
     _ = logly.Terminal.enableAnsiColors();
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/json_extended.zig
+++ b/examples/json_extended.zig
@@ -5,7 +5,7 @@ pub fn main() !void {
     // Enable ANSI colors on Windows
     _ = logly.Terminal.enableAnsiColors();
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/json_logging.zig
+++ b/examples/json_logging.zig
@@ -5,7 +5,7 @@ pub fn main() !void {
     // Enable ANSI colors on Windows
     _ = logly.Terminal.enableAnsiColors();
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/metrics.zig
+++ b/examples/metrics.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/module_levels.zig
+++ b/examples/module_levels.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/network_logging.zig
+++ b/examples/network_logging.zig
@@ -64,7 +64,7 @@ fn udpServer() !void {
 // --- Main Example ---
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -76,7 +76,7 @@ pub fn main() !void {
     udp_thread.detach();
 
     // Give servers a moment to start
-    std.Thread.sleep(500 * std.time.ns_per_ms);
+    logly.Utils.sleepMs(500);
 
     // 2. Initialize logger
     var config = logly.Config.default();
@@ -169,7 +169,7 @@ pub fn main() !void {
     std.debug.print("\n--- Logs sent. Waiting for servers to print output... ---\n", .{});
 
     // Wait a bit for messages to be received/printed by servers
-    std.Thread.sleep(2 * std.time.ns_per_s);
+    logly.Utils.sleepMs(2000);
 
     // Demonstrate Syslog formatting with constants
     std.debug.print("\n--- Syslog Formatting Example ---\n", .{});

--- a/examples/production_config.zig
+++ b/examples/production_config.zig
@@ -4,7 +4,7 @@ const Config = logly.Config;
 const SinkConfig = logly.SinkConfig;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/redaction.zig
+++ b/examples/redaction.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/rotation.zig
+++ b/examples/rotation.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/rules.zig
+++ b/examples/rules.zig
@@ -4,7 +4,7 @@ const logly = @import("logly");
 /// Logly Rules System Demo
 /// Demonstrates compiler-style guided diagnostics for log messages.
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -163,7 +163,8 @@ pub fn main() !void {
     var json_buf: std.ArrayList(u8) = .empty;
     defer json_buf.deinit(allocator);
 
-    try rules.formatMessagesJson(&json_messages, json_buf.writer(allocator), true);
+    var json_writer = logly.Utils.ArrayListWriter.init(&json_buf, allocator);
+    try rules.formatMessagesJson(&json_messages, &json_writer.writer, true);
     std.debug.print("{s}\n\n", .{json_buf.items});
 
     std.debug.print("=== Cleanup ===\n\n", .{});

--- a/examples/sampling.zig
+++ b/examples/sampling.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/scheduler.zig
+++ b/examples/scheduler.zig
@@ -7,7 +7,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/scheduler_demo.zig
+++ b/examples/scheduler_demo.zig
@@ -11,16 +11,17 @@ fn customMetricsTask(task: *Scheduler.ScheduledTask) anyerror!void {
 
 /// Demonstrates the scheduler with comprehensive task implementations and presets.
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
     std.debug.print("\n", .{});
-    std.debug.print("Logly Scheduler Demo v0.1.5\n", .{});
+    std.debug.print("Logly Scheduler Demo v0.1.8\n", .{});
     std.debug.print("Automated Tasks with Compression Integration\n\n", .{});
 
     // Create logs directory for testing
-    std.fs.cwd().makePath("logs_scheduler_test") catch {};
+    const io = logly.Utils.io();
+    std.Io.Dir.cwd().createDirPath(io, "logs_scheduler_test") catch {};
 
     // Create some test log files
     std.debug.print("Creating Test Log Files\n", .{});
@@ -28,16 +29,16 @@ pub fn main() !void {
         const filename = try std.fmt.allocPrint(allocator, "logs_scheduler_test/app_{d}.log", .{i});
         defer allocator.free(filename);
 
-        const file = try std.fs.cwd().createFile(filename, .{});
-        defer file.close();
+        const file = try std.Io.Dir.cwd().createFile(io, filename, .{});
+        defer file.close(io);
 
         // Write some log content
-        const content = try std.fmt.allocPrint(allocator, "[{d}] Log entry {d}: Application running smoothly\n", .{ std.time.timestamp(), i });
+        const content = try std.fmt.allocPrint(allocator, "[{d}] Log entry {d}: Application running smoothly\n", .{ logly.Utils.currentSeconds(), i });
         defer allocator.free(content);
 
         // Write it multiple times to make the file larger
         for (0..100) |_| {
-            try file.writeAll(content);
+            try file.writeStreamingAll(io, content);
         }
 
         std.debug.print("  Created: {s} ({d} bytes)\n", .{ filename, content.len * 100 });
@@ -165,7 +166,7 @@ pub fn main() !void {
         const health = scheduler.getHealthStatus();
         std.debug.print("  Health: {s}\n", .{if (health.healthy) "OK" else "NOT OK"});
 
-        std.Thread.sleep(1 * std.time.ns_per_s);
+        logly.Utils.sleepMs(1000);
     }
 
     // Show final stats
@@ -182,15 +183,15 @@ pub fn main() !void {
 
     // Show remaining files in test directory
     std.debug.print("\nRemaining Test Files\n", .{});
-    var dir = std.fs.cwd().openDir("logs_scheduler_test", .{ .iterate = true }) catch {
+    var dir = std.Io.Dir.cwd().openDir(io, "logs_scheduler_test", .{ .iterate = true }) catch {
         std.debug.print("  (directory cleaned up or not accessible)\n", .{});
         return;
     };
-    defer dir.close();
+    defer dir.close(io);
 
     var file_count: usize = 0;
     var iter = dir.iterate();
-    while (try iter.next()) |entry| {
+    while (try iter.next(io)) |entry| {
         std.debug.print("  - {s}\n", .{entry.name});
         file_count += 1;
     }
@@ -200,7 +201,7 @@ pub fn main() !void {
 
     // Cleanup test directory
     std.debug.print("\nCleanup\n", .{});
-    std.fs.cwd().deleteTree("logs_scheduler_test") catch {};
+    std.Io.Dir.cwd().deleteTree(io, "logs_scheduler_test") catch {};
     std.debug.print("  Removed test directory\n", .{});
 
     std.debug.print("\nScheduler Demo Complete!\n", .{});

--- a/examples/sink_formats.zig
+++ b/examples/sink_formats.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/sink_write_modes.zig
+++ b/examples/sink_write_modes.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/telemetry.zig
+++ b/examples/telemetry.zig
@@ -3,7 +3,7 @@ const logly = @import("logly");
 
 pub fn main() !void {
     // Setup allocator
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -665,7 +665,7 @@ fn highThroughputExample(allocator: std.mem.Allocator) !void {
     defer telemetry.deinit();
 
     // Simulate high-throughput span creation
-    const start_time = std.time.nanoTimestamp();
+    const start_time = logly.Utils.currentNanos();
     var created: u32 = 0;
     while (created < 100) : (created += 1) {
         var span = try telemetry.startSpan("high_throughput_op", .{});
@@ -673,7 +673,7 @@ fn highThroughputExample(allocator: std.mem.Allocator) !void {
         span.end();
         try telemetry.endSpan(&span);
     }
-    const elapsed_ns = std.time.nanoTimestamp() - start_time;
+    const elapsed_ns = logly.Utils.currentNanos() - start_time;
     const elapsed_ms = @as(f64, @floatFromInt(elapsed_ns)) / 1_000_000.0;
 
     try telemetry.exportSpans();

--- a/examples/telemetry_mini.zig
+++ b/examples/telemetry_mini.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -25,7 +25,7 @@ pub fn main() !void {
 
         try span.setAttribute("items.count", .{ .integer = 42 });
         try span.addEvent("started", null);
-        std.time.sleep(10 * std.time.ns_per_ms);
+        logly.Utils.sleepMs(10);
         try span.addEvent("finished", null);
     }
 

--- a/examples/thread_pool.zig
+++ b/examples/thread_pool.zig
@@ -6,7 +6,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/thread_pool_arena.zig
+++ b/examples/thread_pool_arena.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -53,7 +53,7 @@ pub fn main() !void {
 
     // Wait a bit for async logs to flush (since main exits immediately)
     // Using explicit cast to u64 to avoid integer overflow
-    std.Thread.sleep(@as(u64, 100) * std.time.ns_per_ms);
+    logly.Utils.sleepMs(100);
 
     std.debug.print("Done! Check logs/thread_pool_arena.log\n", .{});
 }

--- a/examples/time.zig
+++ b/examples/time.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/tracing.zig
+++ b/examples/tracing.zig
@@ -3,7 +3,7 @@ const logly = @import("logly");
 const Config = logly.Config;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/update_check.zig
+++ b/examples/update_check.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const logly = @import("logly");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -32,7 +32,7 @@ pub fn main() !void {
     std.debug.print("Logger initialized with update check enabled.\n", .{});
     std.debug.print("Waiting for background check (2 seconds)...\n", .{});
 
-    std.Thread.sleep(2 * std.time.ns_per_s);
+    logly.Utils.sleepMs(2000);
 
     std.debug.print("\n=== Update Check Example Complete ===\n", .{});
 }

--- a/src/async.zig
+++ b/src/async.zig
@@ -41,10 +41,9 @@ pub const AsyncLogger = struct {
     buffer: RingBuffer,
     /// Async logger statistics.
     stats: AsyncStats,
-    /// Mutex for thread-safe operations.
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = .init,
     /// Condition variable for worker thread signaling.
-    condition: std.Thread.Condition = .{},
+    condition: std.Io.Condition = .init,
     /// Background worker thread.
     worker_thread: ?std.Thread = null,
     /// Whether the async logger is running.
@@ -399,8 +398,8 @@ pub const AsyncLogger = struct {
     /// Registers a new sink for log output.
     /// Thread-safe.
     pub fn addSink(self: *AsyncLogger, sink: *Sink) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         try self.sinks.append(self.allocator, sink);
     }
 
@@ -440,8 +439,8 @@ pub const AsyncLogger = struct {
         var dropped = false;
 
         {
-            self.mutex.lock();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(Utils.io());
+            defer self.mutex.unlock(Utils.io());
 
             const now = Utils.currentNanos();
 
@@ -471,9 +470,9 @@ pub const AsyncLogger = struct {
                     },
                     .block => {
                         // Wait for space (with timeout to prevent deadlock)
-                        self.mutex.unlock();
-                        std.Thread.sleep(Constants.AsyncConstants.block_sleep_ns);
-                        self.mutex.lock();
+                        self.mutex.unlock(Utils.io());
+                        Utils.sleepNs(Constants.AsyncConstants.block_sleep_ns);
+                        self.mutex.lockUncancelable(Utils.io());
                         if (self.buffer.isFull()) {
                             _ = self.stats.records_dropped.fetchAdd(1, .monotonic);
                             message_to_free = owned_message;
@@ -508,7 +507,7 @@ pub const AsyncLogger = struct {
                     }
 
                     // Signal worker regarding new data
-                    self.condition.signal();
+                    self.condition.signal(Utils.io());
                 } else {
                     // This creates a failsafe if unexpected full state occurs
                     message_to_free = owned_message;
@@ -537,7 +536,7 @@ pub const AsyncLogger = struct {
         if (!self.running.load(.acquire)) return;
 
         self.running.store(false, .release);
-        self.condition.broadcast();
+        self.condition.broadcast(Utils.io());
 
         if (self.worker_thread) |thread| {
             thread.join();
@@ -548,8 +547,8 @@ pub const AsyncLogger = struct {
     /// Synchronously processes all pending messages in the buffer.
     /// This is typically called during shutdown or panic.
     pub fn flushSync(self: *AsyncLogger) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         var batch: [Constants.AsyncConstants.batch_size]BufferEntry = undefined;
         const start_time = Utils.currentMillis();
@@ -581,7 +580,7 @@ pub const AsyncLogger = struct {
 
     /// Signals the worker thread to perform a flush immediately.
     pub fn flush(self: *AsyncLogger) void {
-        self.condition.signal();
+        self.condition.signal(Utils.io());
     }
 
     /// Main loop for the background worker thread.
@@ -601,7 +600,7 @@ pub const AsyncLogger = struct {
         var last_flush = Utils.currentMillis();
 
         while (self.running.load(.acquire) or !self.buffer.isEmpty()) {
-            self.mutex.lock();
+            self.mutex.lockUncancelable(Utils.io());
 
             // Wait for entries or timeout
             const now = Utils.currentMillis();
@@ -609,17 +608,20 @@ pub const AsyncLogger = struct {
 
             if (self.buffer.isEmpty()) {
                 if (self.on_empty) |cb| cb();
-                // Wait with timeout
-                self.condition.timedWait(&self.mutex, self.config.flush_interval_ms * Constants.TimeConstants.ns_per_ms) catch {};
+                self.mutex.unlock(Utils.io());
+                Utils.sleepMs(self.config.flush_interval_ms);
+                self.mutex.lockUncancelable(Utils.io());
             } else if (self.config.min_flush_interval_ms > 0 and elapsed < @as(i64, @intCast(self.config.min_flush_interval_ms))) {
                 // Enforce minimum flush interval
                 const wait_time = self.config.min_flush_interval_ms - @as(u64, @intCast(elapsed));
-                self.condition.timedWait(&self.mutex, wait_time * Constants.TimeConstants.ns_per_ms) catch {};
+                self.mutex.unlock(Utils.io());
+                Utils.sleepMs(wait_time);
+                self.mutex.lockUncancelable(Utils.io());
             }
 
             // Process batch
             const count = self.buffer.popBatch(&batch);
-            self.mutex.unlock();
+            self.mutex.unlock(Utils.io());
 
             if (count > 0) {
                 const write_start = Utils.currentNanos();
@@ -689,22 +691,22 @@ pub const AsyncLogger = struct {
 
     /// Gets current queue depth.
     pub fn queueDepth(self: *AsyncLogger) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         return self.buffer.size();
     }
 
     /// Checks if queue is empty.
     pub fn isQueueEmpty(self: *AsyncLogger) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         return self.buffer.isEmpty();
     }
 
     /// Returns available queue slots before reaching capacity.
     pub fn availableCapacity(self: *AsyncLogger) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         const current_depth = self.buffer.size();
         return if (self.buffer.capacity > current_depth) self.buffer.capacity - current_depth else 0;
@@ -748,7 +750,7 @@ pub const AsyncLogger = struct {
             }
 
             self.flush();
-            std.Thread.sleep(1 * Constants.TimeConstants.ns_per_ms);
+            Utils.sleepMs(1);
         }
     }
 
@@ -809,8 +811,8 @@ pub const AsyncLogger = struct {
 
     /// Returns true if the buffer is full.
     pub fn isFull(self: *AsyncLogger) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         return self.buffer.isFull();
     }
 
@@ -888,10 +890,10 @@ pub const AsyncLogger = struct {
 /// Async file writer for high-performance file logging.
 pub const AsyncFileWriter = struct {
     allocator: std.mem.Allocator,
-    file: std.fs.File,
+    file: std.Io.File,
     buffer: std.ArrayList(u8),
     config: FileConfig,
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = .init,
     flush_thread: ?std.Thread = null,
     running: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     bytes_written: std.atomic.Value(Constants.AtomicUnsigned) = std.atomic.Value(Constants.AtomicUnsigned).init(0),
@@ -908,15 +910,10 @@ pub const AsyncFileWriter = struct {
         const self = try allocator.create(AsyncFileWriter);
         errdefer allocator.destroy(self);
 
-        const file = try std.fs.cwd().createFile(path, .{
+        const file = try std.Io.Dir.cwd().createFile(Utils.io(), path, .{
             .truncate = !config.append_mode,
         });
-        errdefer file.close();
-
-        // Seek to end if appending
-        if (config.append_mode) {
-            try file.seekFromEnd(0);
-        }
+        errdefer file.close(Utils.io());
 
         self.* = .{
             .allocator = allocator,
@@ -936,15 +933,15 @@ pub const AsyncFileWriter = struct {
         self.stop();
         self.flushSync();
         self.buffer.deinit(self.allocator);
-        self.file.close();
+        self.file.close(Utils.io());
         self.allocator.destroy(self);
     }
 
     pub const destroy = deinit;
 
     pub fn write(self: *AsyncFileWriter, data: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         try self.buffer.appendSlice(self.allocator, data);
 
@@ -956,8 +953,8 @@ pub const AsyncFileWriter = struct {
     pub const writeData = write;
 
     pub fn writeLine(self: *AsyncFileWriter, data: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         try self.buffer.appendSlice(self.allocator, data);
         try self.buffer.append(self.allocator, '\n');
@@ -972,11 +969,12 @@ pub const AsyncFileWriter = struct {
     fn flushInternal(self: *AsyncFileWriter) !void {
         if (self.buffer.items.len == 0) return;
 
-        try self.file.writeAll(self.buffer.items);
+        const offset = if (self.config.append_mode) try self.file.length(Utils.io()) else 0;
+        try self.file.writePositionalAll(Utils.io(), self.buffer.items, offset);
         _ = self.bytes_written.fetchAdd(self.buffer.items.len, .monotonic);
 
         if (self.config.sync_on_flush) {
-            try self.file.sync();
+            try self.file.sync(Utils.io());
         }
 
         self.buffer.clearRetainingCapacity();
@@ -984,8 +982,8 @@ pub const AsyncFileWriter = struct {
     }
 
     pub fn flushSync(self: *AsyncFileWriter) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.flushInternal() catch {};
     }
 
@@ -1016,7 +1014,7 @@ pub const AsyncFileWriter = struct {
 
     fn autoFlushLoop(self: *AsyncFileWriter) void {
         while (self.running.load(.acquire)) {
-            std.Thread.sleep(self.config.flush_interval_ms * Constants.TimeConstants.ns_per_ms);
+            Utils.sleepMs(self.config.flush_interval_ms);
             self.flushSync();
         }
     }

--- a/src/compression.zig
+++ b/src/compression.zig
@@ -48,7 +48,7 @@ pub const Compression = struct {
     /// Compression statistics for monitoring.
     stats: CompressionStats,
     /// Mutex for thread-safe operations.
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = std.Io.Mutex.init,
 
     /// Callback invoked before compression starts.
     /// Parameters: (file_path: []const u8, uncompressed_size: u64)
@@ -642,8 +642,8 @@ pub const Compression = struct {
     ///
     /// Complexity: O(1)
     pub fn setCompressionStartCallback(self: *Compression, callback: *const fn ([]const u8, u64) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_compression_start = callback;
     }
 
@@ -655,8 +655,8 @@ pub const Compression = struct {
     ///
     /// Complexity: O(1)
     pub fn setCompressionCompleteCallback(self: *Compression, callback: *const fn ([]const u8, []const u8, u64, u64, u64) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_compression_complete = callback;
     }
 
@@ -668,8 +668,8 @@ pub const Compression = struct {
     ///
     /// Complexity: O(1)
     pub fn setCompressionErrorCallback(self: *Compression, callback: *const fn ([]const u8, anyerror) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_compression_error = callback;
     }
 
@@ -681,8 +681,8 @@ pub const Compression = struct {
     ///
     /// Complexity: O(1)
     pub fn setDecompressionCompleteCallback(self: *Compression, callback: *const fn ([]const u8, []const u8) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_decompression_complete = callback;
     }
 
@@ -694,8 +694,8 @@ pub const Compression = struct {
     ///
     /// Complexity: O(1)
     pub fn setArchiveDeletedCallback(self: *Compression, callback: *const fn ([]const u8) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_archive_deleted = callback;
     }
 
@@ -735,8 +735,8 @@ pub const Compression = struct {
             _ = self.stats.total_compression_time_ns.fetchAdd(@truncate(elapsed), .monotonic);
         }
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.config.algorithm == .none or data.len == 0) {
             const copy = try alloc.dupe(u8, data);
@@ -816,7 +816,8 @@ pub const Compression = struct {
     ///
     /// Complexity: O(N) memory and time.
     pub fn compressStream(self: *Compression, reader: anytype, writer: anytype) !void {
-        const content = try reader.readAllAlloc(self.allocator, std.math.maxInt(usize));
+        var input = reader;
+        const content = try input.allocRemaining(self.allocator, .unlimited);
         defer self.allocator.free(content);
 
         const compressed = try self.compress(content);
@@ -836,7 +837,8 @@ pub const Compression = struct {
     ///
     /// Complexity: O(N) memory and time.
     pub fn decompressStream(self: *Compression, reader: anytype, writer: anytype) !void {
-        const content = try reader.readAllAlloc(self.allocator, std.math.maxInt(usize));
+        var input = reader;
+        const content = try input.allocRemaining(self.allocator, .unlimited);
         defer self.allocator.free(content);
 
         const decompressed = try self.decompress(content);
@@ -1022,7 +1024,7 @@ pub const Compression = struct {
     }
 
     fn compressTarGzWithAllocator(self: *Compression, data: []const u8, result: *std.ArrayList(u8), alloc: std.mem.Allocator) !void {
-        var tar_buf = std.io.Writer.Allocating.init(alloc);
+        var tar_buf = std.Io.Writer.Allocating.init(alloc);
         defer tar_buf.deinit();
 
         var tar_writer: std.tar.Writer = .{ .underlying_writer = &tar_buf.writer };
@@ -1491,7 +1493,7 @@ pub const Compression = struct {
         const tar_data = try self.decompressDeflateNative(data, 0, 0);
         defer alloc.free(tar_data);
 
-        var tar_reader = std.io.Reader.fixed(tar_data);
+        var tar_reader = std.Io.Reader.fixed(tar_data);
 
         const file_name_buf = try alloc.alloc(u8, std.fs.max_path_bytes);
         defer alloc.free(file_name_buf);
@@ -1519,27 +1521,26 @@ pub const Compression = struct {
     /// v0.1.6+
     fn decompressZipWithAllocator(self: *Compression, data: []const u8, original_size: usize, alloc: std.mem.Allocator) ![]u8 {
         _ = alloc;
-        var stream = std.io.fixedBufferStream(data);
-        var reader = stream.reader();
+        var stream = std.Io.Reader.fixed(data);
 
         // Check Local File Header signature
-        const sig = try reader.readInt(u32, .little);
+        const sig = try stream.takeInt(u32, .little);
         if (sig != 0x04034b50) return error.InvalidZipArchive;
 
-        _ = try reader.readInt(u16, .little); // Version needed
-        _ = try reader.readInt(u16, .little); // Flags
-        const compression_method = try reader.readInt(u16, .little);
-        _ = try reader.readInt(u16, .little); // Mod time
-        _ = try reader.readInt(u16, .little); // Mod date
-        _ = try reader.readInt(u32, .little); // CRC32
-        const compressed_size = try reader.readInt(u32, .little);
-        const uncompressed_size = try reader.readInt(u32, .little);
-        const filename_len = try reader.readInt(u16, .little);
-        const extra_len = try reader.readInt(u16, .little);
+        _ = try stream.takeInt(u16, .little); // Version needed
+        _ = try stream.takeInt(u16, .little); // Flags
+        const compression_method = try stream.takeInt(u16, .little);
+        _ = try stream.takeInt(u16, .little); // Mod time
+        _ = try stream.takeInt(u16, .little); // Mod date
+        _ = try stream.takeInt(u32, .little); // CRC32
+        const compressed_size = try stream.takeInt(u32, .little);
+        const uncompressed_size = try stream.takeInt(u32, .little);
+        const filename_len = try stream.takeInt(u16, .little);
+        const extra_len = try stream.takeInt(u16, .little);
 
-        try stream.seekBy(@intCast(filename_len + extra_len));
+        try stream.discardAll(@intCast(filename_len + extra_len));
 
-        const content_compressed = data[stream.pos..][0..compressed_size];
+        const content_compressed = data[stream.seek..][0..compressed_size];
 
         if (compression_method == 0) {
             // Store (no compression)
@@ -1557,16 +1558,15 @@ pub const Compression = struct {
     /// v0.1.6+
     fn decompressLzmaWithAllocator(self: *Compression, data: []const u8, original_size: usize, alloc: std.mem.Allocator) ![]u8 {
         _ = self;
-        var stream = std.io.fixedBufferStream(data);
-        var reader = stream.reader();
+        var stream = std.Io.Reader.fixed(data);
 
         // Header: [properties:1][dict_size:4][uncompressed_size:8]
         if (data.len < 13) return error.InvalidLzmaHeader;
 
-        _ = try reader.readByte(); // properties
-        const dict_size = try reader.readInt(u32, .little);
+        _ = try stream.takeByte(); // properties
+        const dict_size = try stream.takeInt(u32, .little);
         _ = dict_size;
-        const uncompressed_len = try reader.readInt(u64, .little);
+        const uncompressed_len = try stream.takeInt(u64, .little);
 
         if (uncompressed_len > std.math.maxInt(usize)) return error.OutputTooLarge;
         // Use passed original_size if header size is 0 (unknown) or matches max u64 (unknown marker)
@@ -1575,8 +1575,8 @@ pub const Compression = struct {
         var result = try std.ArrayList(u8).initCapacity(alloc, output_size);
         errdefer result.deinit(alloc);
 
-        while (stream.pos < data.len) {
-            const byte = try reader.readByte();
+        while (stream.seek < data.len) {
+            const byte = try stream.takeByte();
 
             if (byte == 0x00) {
                 // End marker
@@ -1585,30 +1585,30 @@ pub const Compression = struct {
                 // Literal run
                 var lit_len: usize = 0;
                 if (byte == 0xFF) {
-                    lit_len = try reader.readInt(u16, .little);
+                    lit_len = try stream.takeInt(u16, .little);
                 } else {
                     lit_len = byte & 0x7F;
                 }
 
-                if (stream.pos + lit_len > data.len) return error.InvalidData;
-                const literals = data[stream.pos..][0..lit_len];
-                try stream.seekBy(@intCast(lit_len));
+                if (stream.seek + lit_len > data.len) return error.InvalidData;
+                const literals = data[stream.seek..][0..lit_len];
+                try stream.discardAll(@intCast(lit_len));
                 try result.appendSlice(alloc, literals);
             } else {
                 // Match
                 if ((byte & 0x40) == 0) {
                     // Short match
                     const len = @as(usize, byte & 0x0F) + 2;
-                    const offset = @as(usize, try reader.readByte());
+                    const offset = @as(usize, try stream.takeByte());
 
                     try copyMatch(&result, alloc, offset, len);
                 } else {
                     // Long match
                     var len = @as(usize, byte & 0x0F) + 2;
-                    const offset = try reader.readInt(u16, .little);
+                    const offset = try stream.takeInt(u16, .little);
 
                     if (len == 17) {
-                        len += @as(usize, try reader.readByte());
+                        len += @as(usize, try stream.takeByte());
                     }
 
                     try copyMatch(&result, alloc, offset, len);
@@ -1638,24 +1638,23 @@ pub const Compression = struct {
         // Control 0x02 = LZMA chunk
         if (data.len < 1) return error.InvalidData;
 
-        var stream = std.io.fixedBufferStream(data);
-        var reader = stream.reader();
+        var stream = std.Io.Reader.fixed(data);
         var result = try std.ArrayList(u8).initCapacity(alloc, original_size);
         errdefer result.deinit(alloc);
 
-        while (stream.pos < data.len) {
-            const control = try reader.readByte();
+        while (stream.seek < data.len) {
+            const control = try stream.takeByte();
             if (control == 0x00) break; // End marker
 
             if (control == 0x02) {
                 // LZMA chunk
-                const unpacked_size = @as(usize, try reader.readInt(u16, .little)) + 1;
-                const packed_size = @as(usize, try reader.readInt(u16, .little)) + 1;
+                const unpacked_size = @as(usize, try stream.takeInt(u16, .little)) + 1;
+                const packed_size = @as(usize, try stream.takeInt(u16, .little)) + 1;
 
-                if (stream.pos + packed_size > data.len) return error.InvalidData;
+                if (stream.seek + packed_size > data.len) return error.InvalidData;
 
-                const chunk_data = data[stream.pos..][0..packed_size];
-                try stream.seekBy(@intCast(packed_size));
+                const chunk_data = data[stream.seek..][0..packed_size];
+                try stream.discardAll(@intCast(packed_size));
 
                 const chunk_decompressed = try self.decompressLzmaWithAllocator(chunk_data, unpacked_size, alloc);
                 defer alloc.free(chunk_decompressed);
@@ -1671,31 +1670,30 @@ pub const Compression = struct {
     /// XZ decompression.
     /// v0.1.6+
     fn decompressXzWithAllocator(self: *Compression, data: []const u8, original_size: usize, alloc: std.mem.Allocator) ![]u8 {
-        var stream = std.io.fixedBufferStream(data);
-        var reader = stream.reader();
+        var stream = std.Io.Reader.fixed(data);
 
         // Check magic
         if (data.len < 12) return error.InvalidData;
         const magic = data[0..6];
-        try stream.seekBy(6);
+        try stream.discardAll(6);
 
         if (!std.mem.eql(u8, magic, Constants.CompressionConstants.Magic.xz)) return error.InvalidMagic;
 
         // Skip Stream Header flags (2 bytes) + CRC (4 bytes)
-        try stream.seekBy(6);
+        try stream.discardAll(6);
 
         // Read Block Header Size
-        const header_size_encoded = try reader.readByte();
+        const header_size_encoded = try stream.takeByte();
         if (header_size_encoded == 0) return error.InvalidData;
 
         const header_size = (@as(usize, header_size_encoded) + 1) * 4;
 
         // Skip Block Header details (flags, filters, etc.)
         // We already read 1 byte (encoded size), so skip header_size - 1
-        try stream.seekBy(@intCast(header_size - 1));
+        try stream.discardAll(@intCast(header_size - 1));
 
         // Decompress LZMA2 data block
-        const decompressed = try self.decompressLzma2WithAllocator(data[stream.pos..], original_size, alloc);
+        const decompressed = try self.decompressLzma2WithAllocator(data[stream.seek..], original_size, alloc);
 
         return decompressed;
     }
@@ -1707,11 +1705,10 @@ pub const Compression = struct {
         var result = try std.ArrayList(u8).initCapacity(alloc, original_size);
         errdefer result.deinit(alloc);
 
-        var stream = std.io.fixedBufferStream(data);
-        var reader = stream.reader();
+        var stream = std.Io.Reader.fixed(data);
 
-        while (stream.pos < data.len) {
-            const token = try reader.readByte();
+        while (stream.seek < data.len) {
+            const token = try stream.takeByte();
 
             // Token: high 4 = literal len, low 4 = match len
             var lit_len: usize = @intCast((token >> 4) & 0x0F);
@@ -1720,27 +1717,27 @@ pub const Compression = struct {
             // Read extended literal length
             if (lit_len == 15) {
                 while (true) {
-                    const byte = try reader.readByte();
+                    const byte = try stream.takeByte();
                     lit_len += byte;
                     if (byte != 255) break;
                 }
             }
 
             // Copy literals
-            if (stream.pos + lit_len > data.len) return error.InvalidData;
-            const literals = data[stream.pos..][0..lit_len];
-            try stream.seekBy(@intCast(lit_len));
+            if (stream.seek + lit_len > data.len) return error.InvalidData;
+            const literals = data[stream.seek..][0..lit_len];
+            try stream.discardAll(@intCast(lit_len));
             try result.appendSlice(alloc, literals);
 
-            if (stream.pos >= data.len) break; // End of stream
+            if (stream.seek >= data.len) break; // End of stream
 
             // Read Offset
-            const offset = try reader.readInt(u16, .little);
+            const offset = try stream.takeInt(u16, .little);
 
             // Read extended match length
             if (ml == 15) {
                 while (true) {
-                    const byte = try reader.readByte();
+                    const byte = try stream.takeByte();
                     ml += byte;
                     if (byte != 255) break;
                 }
@@ -1826,8 +1823,8 @@ pub const Compression = struct {
             _ = self.stats.total_decompression_time_ns.fetchAdd(@truncate(elapsed), .monotonic);
         }
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         // Minimum header size: magic(4) + size(4) + checksum(4) = 12
         if (data.len < 12) return error.InvalidData;
@@ -1970,8 +1967,8 @@ pub const Compression = struct {
     ///
     /// Complexity: O(N) where N is the file size (I/O bound).
     pub fn compressFile(self: *Compression, input_path: []const u8, output_path: ?[]const u8) !CompressionResult {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         const out_path = if (output_path) |p| p else blk: {
             break :blk try std.fmt.allocPrint(self.allocator, "{s}{s}", .{ input_path, self.config.extension });
@@ -1980,7 +1977,7 @@ pub const Compression = struct {
         defer if (should_free_path) self.allocator.free(out_path);
 
         // Get original file size
-        const input_file = std.fs.cwd().openFile(input_path, .{}) catch |err| {
+        const input_file = std.Io.Dir.cwd().openFile(Utils.io(), input_path, .{}) catch |err| {
             _ = self.stats.compression_errors.fetchAdd(1, .monotonic);
             return .{
                 .success = false,
@@ -1990,9 +1987,9 @@ pub const Compression = struct {
                 .error_message = @errorName(err),
             };
         };
-        defer input_file.close();
+        defer input_file.close(Utils.io());
 
-        const stat = try input_file.stat();
+        const stat = try input_file.stat(Utils.io());
         const original_size = stat.size;
 
         // Invoke start callback if registered
@@ -2001,13 +1998,15 @@ pub const Compression = struct {
         }
 
         // Read file content
-        const content = try input_file.readToEndAlloc(self.allocator, std.math.maxInt(usize));
+        var read_buffer: [Constants.BufferSizes.compression]u8 = undefined;
+        var file_reader = input_file.reader(Utils.io(), &read_buffer);
+        const content = try file_reader.interface.allocRemaining(self.allocator, .unlimited);
         defer self.allocator.free(content);
 
         // Compress content
-        self.mutex.unlock(); // Unlock for nested call
+        self.mutex.unlock(Utils.io()); // Unlock for nested call
         const compressed = self.compress(content) catch |err| {
-            self.mutex.lock();
+            self.mutex.lockUncancelable(Utils.io());
             _ = self.stats.compression_errors.fetchAdd(1, .monotonic);
             return .{
                 .success = false,
@@ -2017,12 +2016,12 @@ pub const Compression = struct {
                 .error_message = @errorName(err),
             };
         };
-        self.mutex.lock();
+        self.mutex.lockUncancelable(Utils.io());
         defer self.allocator.free(compressed);
 
         // Create parent directory if needed
         if (std.fs.path.dirname(out_path)) |dirname| {
-            std.fs.cwd().makePath(dirname) catch |err| {
+            std.Io.Dir.cwd().createDirPath(Utils.io(), dirname) catch |err| {
                 _ = self.stats.compression_errors.fetchAdd(1, .monotonic);
                 return .{
                     .success = false,
@@ -2035,7 +2034,7 @@ pub const Compression = struct {
         }
 
         // Write compressed file
-        const output_file = std.fs.cwd().createFile(out_path, .{}) catch |err| {
+        const output_file = std.Io.Dir.cwd().createFile(Utils.io(), out_path, .{}) catch |err| {
             _ = self.stats.compression_errors.fetchAdd(1, .monotonic);
             return .{
                 .success = false,
@@ -2045,13 +2044,13 @@ pub const Compression = struct {
                 .error_message = @errorName(err),
             };
         };
-        defer output_file.close();
+        defer output_file.close(Utils.io());
 
-        try output_file.writeAll(compressed);
+        try output_file.writeStreamingAll(Utils.io(), compressed);
 
         // Delete original if configured
         if (!self.config.keep_original) {
-            std.fs.cwd().deleteFile(input_path) catch {};
+            std.Io.Dir.cwd().deleteFile(Utils.io(), input_path) catch {};
         }
 
         _ = self.stats.files_compressed.fetchAdd(1, .monotonic);
@@ -2084,8 +2083,8 @@ pub const Compression = struct {
     ///
     /// Complexity: O(N) where N is the file size (I/O bound).
     pub fn decompressFile(self: *Compression, input_path: []const u8, output_path: ?[]const u8) !bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         const out_path = if (output_path) |p| p else blk: {
             // Remove extension
@@ -2096,23 +2095,25 @@ pub const Compression = struct {
         };
 
         // Read compressed file
-        const input_file = try std.fs.cwd().openFile(input_path, .{});
-        defer input_file.close();
+        const input_file = try std.Io.Dir.cwd().openFile(Utils.io(), input_path, .{});
+        defer input_file.close(Utils.io());
 
-        const content = try input_file.readToEndAlloc(self.allocator, std.math.maxInt(usize));
+        var read_buffer: [Constants.BufferSizes.compression]u8 = undefined;
+        var file_reader = input_file.reader(Utils.io(), &read_buffer);
+        const content = try file_reader.interface.allocRemaining(self.allocator, .unlimited);
         defer self.allocator.free(content);
 
         // Decompress
-        self.mutex.unlock();
+        self.mutex.unlock(Utils.io());
         const decompressed = try self.decompress(content);
-        self.mutex.lock();
+        self.mutex.lockUncancelable(Utils.io());
         defer self.allocator.free(decompressed);
 
         // Write decompressed file
-        const output_file = try std.fs.cwd().createFile(out_path, .{});
-        defer output_file.close();
+        const output_file = try std.Io.Dir.cwd().createFile(Utils.io(), out_path, .{});
+        defer output_file.close(Utils.io());
 
-        try output_file.writeAll(decompressed);
+        try output_file.writeStreamingAll(Utils.io(), decompressed);
 
         return true;
     }
@@ -2129,13 +2130,13 @@ pub const Compression = struct {
     /// Returns:
     ///     - Number of files successfully compressed.
     pub fn compressDirectory(self: *Compression, dir_path: []const u8) !u64 {
-        var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch return 0;
-        defer dir.close();
+        var dir = std.Io.Dir.cwd().openDir(Utils.io(), dir_path, .{ .iterate = true }) catch return 0;
+        defer dir.close(Utils.io());
 
         var iterator = dir.iterate();
         var count: u64 = 0;
 
-        while (try iterator.next()) |entry| {
+        while (try iterator.next(Utils.io())) |entry| {
             if (entry.kind != .file) continue;
 
             const file_path = try std.fs.path.join(self.allocator, &[_][]const u8{ dir_path, entry.name });
@@ -2175,10 +2176,10 @@ pub const Compression = struct {
         if (std.mem.endsWith(u8, file_path, ".zst")) return false;
 
         if (self.config.mode == .on_size_threshold) {
-            const file = std.fs.cwd().openFile(file_path, .{}) catch return false;
-            defer file.close();
+            const file = std.Io.Dir.cwd().openFile(Utils.io(), file_path, .{}) catch return false;
+            defer file.close(Utils.io());
 
-            const stat = file.stat() catch return false;
+            const stat = file.stat(Utils.io()) catch return false;
             return stat.size >= self.config.size_threshold;
         }
 
@@ -2205,8 +2206,8 @@ pub const Compression = struct {
     ///
     /// Complexity: O(1)
     pub fn resetStats(self: *Compression) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.stats.reset();
     }
 
@@ -2219,8 +2220,8 @@ pub const Compression = struct {
     ///
     /// Complexity: O(1)
     pub fn configure(self: *Compression, config: CompressionConfig) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.config = config;
     }
 
@@ -2365,13 +2366,13 @@ pub const Compression = struct {
     /// Returns:
     ///     Number of files successfully compressed.
     pub fn compressPattern(self: *Compression, dir_path: []const u8, pattern: []const u8) !u64 {
-        var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch return 0;
-        defer dir.close();
+        var dir = std.Io.Dir.cwd().openDir(Utils.io(), dir_path, .{ .iterate = true }) catch return 0;
+        defer dir.close(Utils.io());
 
         var iterator = dir.iterate();
         var count: u64 = 0;
 
-        while (try iterator.next()) |entry| {
+        while (try iterator.next(Utils.io())) |entry| {
             if (entry.kind != .file) continue;
 
             if (matchGlob(entry.name, pattern)) {
@@ -2403,8 +2404,8 @@ pub const Compression = struct {
     /// Returns:
     ///     Number of files successfully compressed.
     pub fn compressOldest(self: *Compression, dir_path: []const u8, count: usize) !u64 {
-        var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch return 0;
-        defer dir.close();
+        var dir = std.Io.Dir.cwd().openDir(Utils.io(), dir_path, .{ .iterate = true }) catch return 0;
+        defer dir.close(Utils.io());
 
         // Collect file info
         var files = std.ArrayList(FileEntry).init(self.allocator);
@@ -2416,7 +2417,7 @@ pub const Compression = struct {
         }
 
         var iterator = dir.iterate();
-        while (try iterator.next()) |entry| {
+        while (try iterator.next(Utils.io())) |entry| {
             if (entry.kind != .file) continue;
 
             const file_path = try std.fs.path.join(self.allocator, &[_][]const u8{ dir_path, entry.name });
@@ -2424,10 +2425,10 @@ pub const Compression = struct {
 
             if (!self.shouldCompress(file_path)) continue;
 
-            const file = std.fs.cwd().openFile(file_path, .{}) catch continue;
-            defer file.close();
+            const file = std.Io.Dir.cwd().openFile(Utils.io(), file_path, .{}) catch continue;
+            defer file.close(Utils.io());
 
-            const stat = file.stat() catch continue;
+            const stat = file.stat(Utils.io()) catch continue;
             try files.append(.{
                 .name = try self.allocator.dupe(u8, entry.name),
                 .mtime = stat.mtime,
@@ -2490,13 +2491,13 @@ pub const Compression = struct {
     /// Returns:
     ///     Number of files successfully compressed.
     pub fn compressLargerThan(self: *Compression, dir_path: []const u8, min_size: u64) !u64 {
-        var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch return 0;
-        defer dir.close();
+        var dir = std.Io.Dir.cwd().openDir(Utils.io(), dir_path, .{ .iterate = true }) catch return 0;
+        defer dir.close(Utils.io());
 
         var iterator = dir.iterate();
         var count: u64 = 0;
 
-        while (try iterator.next()) |entry| {
+        while (try iterator.next(Utils.io())) |entry| {
             if (entry.kind != .file) continue;
 
             const file_path = try std.fs.path.join(self.allocator, &[_][]const u8{ dir_path, entry.name });
@@ -2504,10 +2505,10 @@ pub const Compression = struct {
 
             if (!self.shouldCompress(file_path)) continue;
 
-            const file = std.fs.cwd().openFile(file_path, .{}) catch continue;
-            defer file.close();
+            const file = std.Io.Dir.cwd().openFile(Utils.io(), file_path, .{}) catch continue;
+            defer file.close(Utils.io());
 
-            const stat = file.stat() catch continue;
+            const stat = file.stat(Utils.io()) catch continue;
             if (stat.size < min_size) continue;
 
             const result = self.compressFile(file_path, null) catch continue;
@@ -2776,22 +2777,22 @@ test "streaming compression" {
 
     const data = "Streaming test data" ** 10;
 
-    var in_stream = std.io.fixedBufferStream(data);
-    var out_buffer: std.ArrayList(u8) = .empty; // Use .empty for Unmanaged-style ArrayList
-    defer out_buffer.deinit(allocator);
+    const reader: std.Io.Reader = .fixed(data);
+    var out_buffer = std.Io.Writer.Allocating.init(allocator);
+    defer out_buffer.deinit();
 
-    try comp.compressStream(in_stream.reader(), out_buffer.writer(allocator));
+    try comp.compressStream(reader, &out_buffer.writer);
 
-    try std.testing.expect(out_buffer.items.len > 0);
+    try std.testing.expect(out_buffer.written().len > 0);
 
     // Verify roundtrip
-    var decomp_in_stream = std.io.fixedBufferStream(out_buffer.items);
-    var decomp_out_buffer: std.ArrayList(u8) = .empty;
-    defer decomp_out_buffer.deinit(allocator);
+    const decomp_in_stream = std.Io.Reader.fixed(out_buffer.written());
+    var decomp_out_buffer = std.Io.Writer.Allocating.init(allocator);
+    defer decomp_out_buffer.deinit();
 
-    try comp.decompressStream(decomp_in_stream.reader(), decomp_out_buffer.writer(allocator));
+    try comp.decompressStream(decomp_in_stream, &decomp_out_buffer.writer);
 
-    try std.testing.expectEqualStrings(data, decomp_out_buffer.items);
+    try std.testing.expectEqualStrings(data, decomp_out_buffer.written());
 }
 
 test "gzip algorithm" {
@@ -2824,14 +2825,14 @@ test "file compression with auto-directory creation" {
     const output_file = "test_output_compression/nested/dirs/output.log.gz";
 
     // Clean up before test
-    std.fs.cwd().deleteTree(test_dir) catch {};
-    defer std.fs.cwd().deleteTree(test_dir) catch {};
+    std.Io.Dir.cwd().deleteTree(Utils.io(), test_dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(Utils.io(), test_dir) catch {};
 
     // Create a dummy source file
-    const file = try std.fs.cwd().createFile(test_file, .{});
-    try file.writeAll("Test content for compression");
-    file.close();
-    defer std.fs.cwd().deleteFile(test_file) catch {};
+    const file = try std.Io.Dir.cwd().createFile(Utils.io(), test_file, .{});
+    try file.writeStreamingAll(Utils.io(), "Test content for compression");
+    file.close(Utils.io());
+    defer std.Io.Dir.cwd().deleteFile(Utils.io(), test_file) catch {};
 
     // Compress with deep path that doesn't exist yet
     const result = try comp.compressFile(test_file, output_file);
@@ -2843,7 +2844,7 @@ test "file compression with auto-directory creation" {
     }
 
     // Verify directory was created
-    const stat = try std.fs.cwd().statFile(output_file);
+    const stat = try std.Io.Dir.cwd().statFile(Utils.io(), output_file, .{});
     try std.testing.expect(stat.size > 0);
 }
 
@@ -2855,18 +2856,18 @@ test "directory compression" {
     const test_dir = "test_batch_compression";
 
     // Setup test directory
-    std.fs.cwd().deleteTree(test_dir) catch {};
-    try std.fs.cwd().makePath(test_dir);
-    defer std.fs.cwd().deleteTree(test_dir) catch {};
+    std.Io.Dir.cwd().deleteTree(Utils.io(), test_dir) catch {};
+    try std.Io.Dir.cwd().createDirPath(Utils.io(), test_dir);
+    defer std.Io.Dir.cwd().deleteTree(Utils.io(), test_dir) catch {};
 
     // Create multiple log files
     const files = [_][]const u8{ "log1.log", "log2.log", "skip.txt" };
     for (files) |fname| {
         const p = try std.fs.path.join(allocator, &[_][]const u8{ test_dir, fname });
         defer allocator.free(p);
-        const f = try std.fs.cwd().createFile(p, .{});
-        try f.writeAll("Log data content");
-        f.close();
+        const f = try std.Io.Dir.cwd().createFile(Utils.io(), p, .{});
+        try f.writeStreamingAll(Utils.io(), "Log data content");
+        f.close(Utils.io());
     }
 
     // configure to only compress .log files if we were filtering extensions,
@@ -2879,12 +2880,12 @@ test "directory compression" {
     try std.testing.expectEqual(@as(u64, 3), compressed_count);
 
     // Verify .gz files exist
-    var dir = try std.fs.cwd().openDir(test_dir, .{ .iterate = true });
-    defer dir.close();
+    var dir = try std.Io.Dir.cwd().openDir(Utils.io(), test_dir, .{ .iterate = true });
+    defer dir.close(Utils.io());
 
     var count: usize = 0;
     var it = dir.iterate();
-    while (try it.next()) |entry| {
+    while (try it.next(Utils.io())) |entry| {
         if (std.mem.endsWith(u8, entry.name, ".gz")) {
             count += 1;
         }

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -27,13 +27,13 @@ var colorBufs: [8][32]u8 = undefined;
 /// current and future 32-bit / 64-bit architectures.
 ///
 /// Fixes: https://github.com/muhammad-fiaz/logly.zig/issues/11
-pub const AtomicUnsigned = std.meta.Int(.unsigned, @bitSizeOf(usize));
+pub const AtomicUnsigned = @Int(.unsigned, @bitSizeOf(usize));
 
 /// Architecture-dependent signed atomic integer type.
 ///
 /// Derived from native pointer width to keep signed counters aligned with
 /// platform word size across 32-bit and 64-bit targets.
-pub const AtomicSigned = std.meta.Int(.signed, @bitSizeOf(usize));
+pub const AtomicSigned = @Int(.signed, @bitSizeOf(usize));
 
 /// Native pointer-sized unsigned integer for the target architecture.
 pub const NativeUint = usize;
@@ -172,7 +172,7 @@ pub const TimeDefaults = struct {
 /// Complexity: O(1)
 pub const AsyncConstants = struct {
     /// Sleep duration when blocking on full queue.
-    pub const block_sleep_ns: u64 = 1 * std.time.ns_per_ms;
+    pub const block_sleep_ns: u64 = 1 * TimeConstants.ns_per_ms;
     /// Default batch size for async processing.
     pub const batch_size: usize = BufferSizes.async_batch;
 };
@@ -208,7 +208,7 @@ pub const ThreadDefaults = struct {
     /// Default stack size for worker threads.
     pub const stack_size: usize = 1024 * 1024; // 1MB
     /// Default wait timeout in nanoseconds.
-    pub const wait_timeout_ns: u64 = 100 * std.time.ns_per_ms;
+    pub const wait_timeout_ns: u64 = 100 * TimeConstants.ns_per_ms;
     /// Maximum concurrent tasks.
     pub const max_tasks: usize = 10000;
     /// Queue size for low resource environments.

--- a/src/diagnostics.zig
+++ b/src/diagnostics.zig
@@ -27,6 +27,7 @@ const std = @import("std");
 const builtin = @import("builtin");
 const SinkConfig = @import("sink.zig").SinkConfig;
 const Constants = @import("constants.zig");
+const Utils = @import("utils.zig");
 
 /// Windows kernel32 API bindings for system diagnostics.
 /// Provides access to memory status and drive enumeration functions.
@@ -221,11 +222,14 @@ fn getWindowsMemory() ?struct { total: u64, avail: u64 } {
 }
 
 fn getLinuxMemory() ?struct { total: u64, avail: u64 } {
-    const file = std.fs.openFileAbsolute("/proc/meminfo", .{}) catch return null;
-    defer file.close();
+    const io = Utils.io();
+    const file = std.Io.Dir.openFileAbsolute(io, "/proc/meminfo", .{}) catch return null;
+    defer file.close(io);
 
     var buf: [Constants.BufferSizes.file_read]u8 = undefined;
-    const len = file.readAll(&buf) catch return null;
+    var file_buffer: [4096]u8 = undefined;
+    var reader = file.reader(io, &file_buffer);
+    const len = reader.interface.readSliceShort(&buf) catch return null;
     const content = buf[0..len];
 
     var total: u64 = 0;
@@ -266,11 +270,14 @@ fn getMacMemory() ?struct { total: u64, avail: u64 } {
 }
 
 fn collectLinuxDrives(allocator: std.mem.Allocator, list: *std.ArrayList(DriveInfo)) !void {
-    const file = std.fs.openFileAbsolute("/proc/mounts", .{}) catch return;
-    defer file.close();
+    const io = Utils.io();
+    const file = std.Io.Dir.openFileAbsolute(io, "/proc/mounts", .{}) catch return;
+    defer file.close(io);
 
     var buf: [Constants.BufferSizes.file_read_large]u8 = undefined;
-    const len = file.readAll(&buf) catch return;
+    var file_buffer: [4096]u8 = undefined;
+    var reader = file.reader(io, &file_buffer);
+    const len = reader.interface.readSliceShort(&buf) catch return;
     const content = buf[0..len];
 
     var lines = std.mem.tokenizeAny(u8, content, "\n");

--- a/src/filter.zig
+++ b/src/filter.zig
@@ -127,7 +127,7 @@ pub const Filter = struct {
     allocator: std.mem.Allocator,
     rules: std.ArrayList(FilterRule),
     stats: FilterStats = .{},
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = std.Io.Mutex.init,
     mode: Mode = .all,
     enabled: bool = true,
 
@@ -255,8 +255,8 @@ pub const Filter = struct {
 
     /// Adds a new filter rule.
     pub fn addRule(self: *Filter, rule: FilterRule) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         // Deep copy patterns and keys if present
         var new_rule = rule;
@@ -277,36 +277,36 @@ pub const Filter = struct {
 
     /// Sets the callback for record allowed events.
     pub fn setAllowedCallback(self: *Filter, callback: *const fn (*const Record, u32) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_record_allowed = callback;
     }
 
     /// Sets the callback for record denied events.
     pub fn setDeniedCallback(self: *Filter, callback: *const fn (*const Record, u32) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_record_denied = callback;
     }
 
     /// Sets the callback for filter creation.
     pub fn setCreatedCallback(self: *Filter, callback: *const fn (*const FilterStats) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_filter_created = callback;
     }
 
     /// Sets the callback for rule addition.
     pub fn setRuleAddedCallback(self: *Filter, callback: *const fn (u32, u32) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_rule_added = callback;
     }
 
     /// Returns filter statistics.
     pub fn getStats(self: *Filter) FilterStats {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         return self.stats;
     }

--- a/src/formatter.zig
+++ b/src/formatter.zig
@@ -220,7 +220,7 @@ pub const Formatter = struct {
     /// Formatter statistics.
     stats: FormatterStats = .{},
     /// Mutex for thread-safe operations.
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = std.Io.Mutex.init,
 
     /// Cached hostname of the current machine.
     hostname: ?[]const u8 = null,
@@ -520,43 +520,43 @@ pub const Formatter = struct {
 
     /// Sets the callback for format completion.
     pub fn setFormatCompleteCallback(self: *Formatter, callback: *const fn (u32, u64) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_format_complete = callback;
     }
 
     /// Sets the callback for JSON formatting.
     pub fn setJsonFormatCallback(self: *Formatter, callback: *const fn (*const Record, u64) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_json_format = callback;
     }
 
     /// Sets the callback for custom formatting.
     pub fn setCustomFormatCallback(self: *Formatter, callback: *const fn ([]const u8, u64) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_custom_format = callback;
     }
 
     /// Sets the callback for format errors.
     pub fn setErrorCallback(self: *Formatter, callback: *const fn ([]const u8) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_format_error = callback;
     }
 
     /// Sets a custom color theme.
     pub fn setTheme(self: *Formatter, theme: Theme) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.theme = theme;
     }
 
     /// Returns formatter statistics.
     pub fn getStats(self: *Formatter) FormatterStats {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         return self.stats;
     }
@@ -605,8 +605,8 @@ pub const Formatter = struct {
             _ = elapsed;
         }
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.configIsJson(config)) {
             const res = try self.formatJsonWithAllocator(record, config, scratch_allocator);
@@ -614,9 +614,9 @@ pub const Formatter = struct {
             return res;
         }
 
-        var buf: std.ArrayList(u8) = .empty;
-        errdefer buf.deinit(alloc);
-        const writer = buf.writer(alloc);
+        var buf = std.Io.Writer.Allocating.init(alloc);
+        errdefer buf.deinit();
+        const writer = &buf.writer;
 
         if (self.configIsCustom(config)) {
             _ = self.stats.custom_formats.fetchAdd(1, .monotonic);
@@ -625,10 +625,10 @@ pub const Formatter = struct {
         try self.formatToWriter(writer, record, config);
 
         if (self.on_format_complete) |cb| {
-            cb(0, buf.items.len);
+            cb(0, buf.written().len);
         }
 
-        const res = try buf.toOwnedSlice(alloc);
+        const res = try buf.toOwnedSlice();
         bytes_formatted = res.len;
         return res;
     }
@@ -655,11 +655,11 @@ pub const Formatter = struct {
     /// Formats a timestamp string using an optional scratch allocator.
     pub fn formatTimestampWithAllocator(self: *Formatter, timestamp_ms: i64, config: anytype, scratch_allocator: ?std.mem.Allocator) ![]u8 {
         const alloc = scratch_allocator orelse self.allocator;
-        var buf: std.ArrayList(u8) = .empty;
-        errdefer buf.deinit(alloc);
+        var buf = std.Io.Writer.Allocating.init(alloc);
+        errdefer buf.deinit();
 
-        try self.writeTimestamp(buf.writer(alloc), timestamp_ms, config);
-        return buf.toOwnedSlice(alloc);
+        try self.writeTimestamp(&buf.writer, timestamp_ms, config);
+        return buf.toOwnedSlice();
     }
 
     /// Formats a log record directly to a writer.
@@ -830,19 +830,8 @@ pub const Formatter = struct {
 
                     for (st.instruction_addresses[0..count]) |addr| {
                         if (self.debug_info) |di| {
-                            // Attempt to get module and symbol
-                            // Note: getSymbolAtAddress allocates unless we provide a buffer,
-                            // but here it uses di.allocator which is typically gpa
-                            if (di.getModuleForAddress(addr) catch null) |module| {
-                                if (module.getSymbolAtAddress(di.allocator, addr) catch null) |symbol| {
-                                    if (symbol.source_location) |sl| {
-                                        try writer.print("  {s} ({s}:{d})\n", .{ symbol.name, sl.file_name, sl.line });
-                                    } else {
-                                        try writer.print("  {s}\n", .{symbol.name});
-                                    }
-                                } else {
-                                    try writer.print("  0x{x}\n", .{addr});
-                                }
+                            if (di.getModuleName(Utils.io(), addr) catch null) |module_name| {
+                                try writer.print("  {s}:0x{x}\n", .{ module_name, addr });
                             } else {
                                 try writer.print("  0x{x}\n", .{addr});
                             }
@@ -1006,18 +995,18 @@ pub const Formatter = struct {
     /// Complexity: O(N)
     pub fn formatJsonWithAllocator(self: *Formatter, record: *const Record, config: anytype, scratch_allocator: ?std.mem.Allocator) ![]u8 {
         const alloc = scratch_allocator orelse self.allocator;
-        var buf: std.ArrayList(u8) = .empty;
-        errdefer buf.deinit(alloc);
-        const writer = buf.writer(alloc);
+        var buf = std.Io.Writer.Allocating.init(alloc);
+        errdefer buf.deinit();
+        const writer = &buf.writer;
         try self.formatJsonToWriter(writer, record, config);
 
         _ = self.stats.json_formats.fetchAdd(1, .monotonic);
 
         if (self.on_json_format) |cb| {
-            cb(record, buf.items.len);
+            cb(record, buf.written().len);
         }
 
-        return buf.toOwnedSlice(alloc);
+        return buf.toOwnedSlice();
     }
 
     /// Formats a log record as JSON directly to a writer.
@@ -1220,16 +1209,8 @@ pub const Formatter = struct {
                     if (!first_addr) try writer.writeAll(", ");
 
                     if (self.debug_info) |di| {
-                        if (di.getModuleForAddress(addr) catch null) |module| {
-                            if (module.getSymbolAtAddress(di.allocator, addr) catch null) |symbol| {
-                                if (symbol.source_location) |sl| {
-                                    try writer.print("\"{s} ({s}:{d})\"", .{ symbol.name, sl.file_name, sl.line });
-                                } else {
-                                    try writer.print("\"{s}\"", .{symbol.name});
-                                }
-                            } else {
-                                try writer.print("\"{x}\"", .{addr});
-                            }
+                        if (di.getModuleName(Utils.io(), addr) catch null) |module_name| {
+                            try writer.print("\"{s}:0x{x}\"", .{ module_name, addr });
                         } else {
                             try writer.print("\"{x}\"", .{addr});
                         }
@@ -1493,10 +1474,9 @@ pub const FormatterPresets = struct {
 
 /// Formats an offset suffix for test assertions.
 fn formatOffsetSuffixForTest(buf: []u8, offset_minutes: i16) ![]const u8 {
-    var fbs = std.io.fixedBufferStream(buf);
-    try Utils.writeUtcOffset(fbs.writer(), offset_minutes);
-
-    return fbs.getWritten();
+    var writer = std.Io.Writer.fixed(buf);
+    try Utils.writeUtcOffset(&writer, offset_minutes);
+    return buf[0..writer.end];
 }
 
 test "formatter ISO8601 UTC uses Z suffix" {
@@ -1512,11 +1492,11 @@ test "formatter ISO8601 UTC uses Z suffix" {
     config.time_format = Config.TimeFormat.iso8601;
     config.timezone = .utc;
 
-    var buf: std.ArrayList(u8) = .{};
-    defer buf.deinit(allocator);
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    defer buf.deinit();
 
-    try formatter.formatJsonToWriter(buf.writer(allocator), &record, config);
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, "Z\"") != null);
+    try formatter.formatJsonToWriter(&buf.writer, &record, config);
+    try std.testing.expect(std.mem.indexOf(u8, buf.written(), "Z\"") != null);
 }
 
 test "formatter ISO8601 local uses local offset suffix" {
@@ -1532,17 +1512,17 @@ test "formatter ISO8601 local uses local offset suffix" {
     config.time_format = Config.TimeFormat.iso8601;
     config.timezone = .local;
 
-    var buf: std.ArrayList(u8) = .{};
-    defer buf.deinit(allocator);
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    defer buf.deinit();
 
-    try formatter.formatJsonToWriter(buf.writer(allocator), &record, config);
+    try formatter.formatJsonToWriter(&buf.writer, &record, config);
 
     const offset_minutes = Utils.localUtcOffsetMinutes(record.timestamp);
     var expected_offset_buf: [6]u8 = undefined;
     const expected_offset = try formatOffsetSuffixForTest(&expected_offset_buf, offset_minutes);
 
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, expected_offset) != null);
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, "Z\"") == null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.written(), expected_offset) != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.written(), "Z\"") == null);
 }
 
 test "formatter RFC3339 UTC uses +00:00 suffix" {
@@ -1558,11 +1538,11 @@ test "formatter RFC3339 UTC uses +00:00 suffix" {
     config.time_format = Config.TimeFormat.rfc3339;
     config.timezone = .utc;
 
-    var buf: std.ArrayList(u8) = .{};
-    defer buf.deinit(allocator);
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    defer buf.deinit();
 
-    try formatter.formatJsonToWriter(buf.writer(allocator), &record, config);
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, "+00:00\"") != null);
+    try formatter.formatJsonToWriter(&buf.writer, &record, config);
+    try std.testing.expect(std.mem.indexOf(u8, buf.written(), "+00:00\"") != null);
 }
 
 test "formatter RFC3339 local uses local offset suffix" {
@@ -1578,16 +1558,16 @@ test "formatter RFC3339 local uses local offset suffix" {
     config.time_format = Config.TimeFormat.rfc3339;
     config.timezone = .local;
 
-    var buf: std.ArrayList(u8) = .{};
-    defer buf.deinit(allocator);
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    defer buf.deinit();
 
-    try formatter.formatJsonToWriter(buf.writer(allocator), &record, config);
+    try formatter.formatJsonToWriter(&buf.writer, &record, config);
 
     const offset_minutes = Utils.localUtcOffsetMinutes(record.timestamp);
     var expected_offset_buf: [6]u8 = undefined;
     const expected_offset = try formatOffsetSuffixForTest(&expected_offset_buf, offset_minutes);
 
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, expected_offset) != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.written(), expected_offset) != null);
 }
 
 test "formatter unix and unix_ms remain numeric" {
@@ -1603,22 +1583,22 @@ test "formatter unix and unix_ms remain numeric" {
     unix_config.time_format = Config.TimeFormat.unix;
     unix_config.timezone = .local;
 
-    var unix_buf: std.ArrayList(u8) = .{};
-    defer unix_buf.deinit(allocator);
+    var unix_buf = std.Io.Writer.Allocating.init(allocator);
+    defer unix_buf.deinit();
 
-    try formatter.formatJsonToWriter(unix_buf.writer(allocator), &record, unix_config);
-    try std.testing.expect(std.mem.indexOf(u8, unix_buf.items, "\"timestamp\":1700000000") != null);
+    try formatter.formatJsonToWriter(&unix_buf.writer, &record, unix_config);
+    try std.testing.expect(std.mem.indexOf(u8, unix_buf.written(), "\"timestamp\":1700000000") != null);
 
     var unix_ms_config = Config{};
     unix_ms_config.time_format = Config.TimeFormat.unix_ms;
     unix_ms_config.timezone = .local;
 
-    var unix_ms_buf: std.ArrayList(u8) = .{};
-    defer unix_ms_buf.deinit(allocator);
+    var unix_ms_buf = std.Io.Writer.Allocating.init(allocator);
+    defer unix_ms_buf.deinit();
 
-    try formatter.formatJsonToWriter(unix_ms_buf.writer(allocator), &record, unix_ms_config);
-    try std.testing.expect(std.mem.indexOf(u8, unix_ms_buf.items, "\"timestamp\":1700000000123") != null);
-    try std.testing.expect(std.mem.indexOf(u8, unix_ms_buf.items, "\"timestamp\":\"1700000000123\"") == null);
+    try formatter.formatJsonToWriter(&unix_ms_buf.writer, &record, unix_ms_config);
+    try std.testing.expect(std.mem.indexOf(u8, unix_ms_buf.written(), "\"timestamp\":1700000000123") != null);
+    try std.testing.expect(std.mem.indexOf(u8, unix_ms_buf.written(), "\"timestamp\":\"1700000000123\"") == null);
 }
 
 test "formatter default time format alias maps to configured default pattern" {
@@ -1634,13 +1614,13 @@ test "formatter default time format alias maps to configured default pattern" {
     config.timezone = .utc;
     config.time_format = Config.TimeFormat.default_alias;
 
-    var buf: std.ArrayList(u8) = .{};
-    defer buf.deinit(allocator);
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    defer buf.deinit();
 
-    try formatter.formatJsonToWriter(buf.writer(allocator), &record, config);
+    try formatter.formatJsonToWriter(&buf.writer, &record, config);
 
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, "\"timestamp\":\"") != null);
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, "default") == null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.written(), "\"timestamp\":\"") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.written(), "default") == null);
 }
 
 test "formatter custom pattern supports timezone tokens" {
@@ -1656,22 +1636,22 @@ test "formatter custom pattern supports timezone tokens" {
     config.timezone = .local;
     config.time_format = "YYYY-MM-DD HH:mm:ss ZZZ ZZ";
 
-    var buf: std.ArrayList(u8) = .{};
-    defer buf.deinit(allocator);
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    defer buf.deinit();
 
-    try formatter.formatJsonToWriter(buf.writer(allocator), &record, config);
+    try formatter.formatJsonToWriter(&buf.writer, &record, config);
 
     const offset_minutes = Utils.localUtcOffsetMinutes(record.timestamp);
     var expected_colon_buf: [6]u8 = undefined;
     const expected_colon = try formatOffsetSuffixForTest(&expected_colon_buf, offset_minutes);
 
     var expected_compact_buf: [5]u8 = undefined;
-    var compact_fbs = std.io.fixedBufferStream(&expected_compact_buf);
-    try Utils.writeUtcOffsetCompact(compact_fbs.writer(), offset_minutes);
-    const expected_compact = compact_fbs.getWritten();
+    var compact_writer = std.Io.Writer.fixed(&expected_compact_buf);
+    try Utils.writeUtcOffsetCompact(&compact_writer, offset_minutes);
+    const expected_compact = expected_compact_buf[0..compact_writer.end];
 
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, expected_colon) != null);
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, expected_compact) != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.written(), expected_colon) != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.written(), expected_compact) != null);
 }
 
 test "formatter timestamp helper formats numeric and textual values" {
@@ -1708,11 +1688,11 @@ test "formatter plain text" {
     record.module = "test_mod";
     record.timestamp = 1700000000000;
 
-    var buf: std.ArrayList(u8) = .{};
-    defer buf.deinit(allocator);
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    defer buf.deinit();
 
-    try formatter.formatToWriter(buf.writer(allocator), &record, Config{});
-    const output_str = buf.items;
+    try formatter.formatToWriter(&buf.writer, &record, Config{});
+    const output_str = buf.written();
 
     try std.testing.expect(std.mem.indexOf(u8, output_str, "INFO") != null);
     try std.testing.expect(std.mem.indexOf(u8, output_str, "test_mod") != null);
@@ -1729,11 +1709,11 @@ test "formatter json" {
     record.module = "api";
     record.timestamp = 1700000000000;
 
-    var buf: std.ArrayList(u8) = .{};
-    defer buf.deinit(allocator);
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    defer buf.deinit();
 
-    try formatter.formatJsonToWriter(buf.writer(allocator), &record, Config{});
-    const output_str = buf.items;
+    try formatter.formatJsonToWriter(&buf.writer, &record, Config{});
+    const output_str = buf.written();
 
     try std.testing.expect(std.mem.indexOf(u8, output_str, "\"level\":\"ERROR\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, output_str, "\"message\":\"Error occurred\"") != null);
@@ -1757,11 +1737,11 @@ test "formatter json distributed fields" {
     config.distributed.service_name = "test-service";
     config.distributed.region = "us-east-1";
 
-    var buf: std.ArrayList(u8) = .{};
-    defer buf.deinit(allocator);
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    defer buf.deinit();
 
-    try formatter.formatJsonToWriter(buf.writer(allocator), &record, config);
-    const output_str = buf.items;
+    try formatter.formatJsonToWriter(&buf.writer, &record, config);
+    const output_str = buf.written();
 
     try std.testing.expect(std.mem.indexOf(u8, output_str, "\"service\":\"test-service\"") != null);
     try std.testing.expect(std.mem.indexOf(u8, output_str, "\"region\":\"us-east-1\"") != null);

--- a/src/logger.zig
+++ b/src/logger.zig
@@ -154,7 +154,7 @@ pub const Logger = struct {
     /// Atomic log level for thread-safe level checking.
     atomic_level: std.atomic.Value(u8) = std.atomic.Value(u8).init(@intFromEnum(Level.info)),
     /// Read-write lock for thread-safe access.
-    mutex: std.Thread.RwLock = .{},
+    mutex: std.Io.RwLock = std.Io.RwLock.init,
     /// Legacy callback for log events.
     log_callback: ?*const fn (*const Record) anyerror!void = null,
     /// Custom color callback for level-based coloring.
@@ -424,8 +424,8 @@ pub const Logger = struct {
     /// Arguments:
     ///     config: The new configuration object.
     pub fn configure(self: *Logger, config: Config) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         const has_arena = self.arena_state != null;
         const wants_arena = config.use_arena_allocator;
@@ -455,8 +455,8 @@ pub const Logger = struct {
     /// Arguments:
     ///     filter: The filter instance to use.
     pub fn setFilter(self: *Logger, filter: *Filter) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.filter = filter;
     }
 
@@ -468,8 +468,8 @@ pub const Logger = struct {
     /// Arguments:
     ///     sampler: The sampler instance to use.
     pub fn setSampler(self: *Logger, sampler: *Sampler) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.sampler = sampler;
     }
 
@@ -481,21 +481,21 @@ pub const Logger = struct {
     /// Arguments:
     ///     redactor: The redactor instance to use.
     pub fn setRedactor(self: *Logger, redactor: *Redactor) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.redactor = redactor;
     }
 
     pub fn setRules(self: *Logger, rules: *Rules) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.rules = rules;
     }
 
     /// Enables metrics collection.
     pub fn enableMetrics(self: *Logger) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         if (self.metrics == null) {
             const m = self.allocator.create(Metrics) catch return;
             m.* = Metrics.init(self.allocator);
@@ -521,8 +521,8 @@ pub const Logger = struct {
     ///     span_id: The span identifier (optional).
     pub fn setTraceContext(self: *Logger, trace_id: []const u8, span_id: ?[]const u8) !void {
         {
-            self.mutex.lock();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(Utils.io());
+            defer self.mutex.unlock(Utils.io());
 
             if (self.trace_id) |t| self.allocator.free(t);
             self.trace_id = try self.allocator.dupe(u8, trace_id);
@@ -550,8 +550,8 @@ pub const Logger = struct {
     /// Arguments:
     ///     correlation_id: The correlation identifier.
     pub fn setCorrelationId(self: *Logger, correlation_id: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.correlation_id) |c| self.allocator.free(c);
         self.correlation_id = try self.allocator.dupe(u8, correlation_id);
@@ -559,8 +559,8 @@ pub const Logger = struct {
 
     /// Clears the trace context.
     pub fn clearTraceContext(self: *Logger) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.trace_id) |t| {
             self.allocator.free(t);
@@ -580,8 +580,8 @@ pub const Logger = struct {
     ///
     /// Returns `null` when trace or span context is missing.
     pub fn getTraceparentHeader(self: *Logger, allocator: std.mem.Allocator) !?[]u8 {
-        self.mutex.lockShared();
-        defer self.mutex.unlockShared();
+        self.mutex.lockSharedUncancelable(Utils.io());
+        defer self.mutex.unlockShared(Utils.io());
 
         const trace_id = self.trace_id orelse return null;
         const span_id = self.span_id orelse return null;
@@ -600,9 +600,9 @@ pub const Logger = struct {
         const parent_span = self.span_id;
         const new_span = try Record.generateSpanId(self.allocator);
 
-        self.mutex.lock();
+        self.mutex.lockUncancelable(Utils.io());
         self.span_id = new_span;
-        self.mutex.unlock();
+        self.mutex.unlock(Utils.io());
 
         if (self.config.distributed.on_span_created) |callback| {
             callback(new_span, name);
@@ -626,8 +626,8 @@ pub const Logger = struct {
     ///
     /// Also available as: `logger.add(config)`
     pub fn addSink(self: *Logger, config: SinkConfig) !usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         // Handle logs_root_path: if set and config.path exists, prepend root to path
         var modified_config = config;
@@ -638,7 +638,7 @@ pub const Logger = struct {
             const file = config.path.?;
 
             // Auto-create root directory if it doesn't exist
-            std.fs.cwd().makePath(root) catch |e| {
+            std.Io.Dir.cwd().createDirPath(Utils.io(), root) catch |e| {
                 if (self.config.debug_mode) {
                     std.debug.print("warning: failed to auto-create logs root path '{s}': {}\n", .{ root, e });
                 }
@@ -671,8 +671,8 @@ pub const Logger = struct {
     /// Removes a sink by index.
     /// Thread-safe: Uses mutex for concurrent access protection.
     pub fn removeSink(self: *Logger, id: usize) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.async_logger != null) {
             // Async logger doesn't support removing sinks dynamically
@@ -694,8 +694,8 @@ pub const Logger = struct {
     /// Returns:
     ///     The number of sinks removed.
     pub fn removeAllSinks(self: *Logger) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.async_logger != null) {
             // Async logger doesn't support removing sinks dynamically
@@ -717,8 +717,8 @@ pub const Logger = struct {
     /// Enables a sink by index.
     /// Thread-safe: Uses mutex for concurrent access protection.
     pub fn enableSink(self: *Logger, id: usize) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (id < self.sinks.items.len) {
             self.sinks.items[id].enabled = true;
@@ -728,8 +728,8 @@ pub const Logger = struct {
     /// Disables a sink by index.
     /// Thread-safe: Uses mutex for concurrent access protection.
     pub fn disableSink(self: *Logger, id: usize) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (id < self.sinks.items.len) {
             self.sinks.items[id].enabled = false;
@@ -739,16 +739,16 @@ pub const Logger = struct {
     /// Returns the number of sinks.
     /// Thread-safe: Uses mutex for concurrent access protection.
     pub fn getSinkCount(self: *Logger) usize {
-        self.mutex.lockShared();
-        defer self.mutex.unlockShared();
+        self.mutex.lockSharedUncancelable(Utils.io());
+        defer self.mutex.unlockShared(Utils.io());
         return self.sinks.items.len;
     }
 
     /// Enables async logging if an async logger is configured.
     /// Thread-safe: Uses mutex for concurrent access protection.
     pub fn enableAsync(self: *Logger) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.async_logger) |al| {
             al.running.store(true, .monotonic);
@@ -758,8 +758,8 @@ pub const Logger = struct {
     /// Disables async logging if an async logger is configured.
     /// Thread-safe: Uses mutex for concurrent access protection.
     pub fn disableAsync(self: *Logger) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.async_logger) |al| {
             al.running.store(false, .monotonic);
@@ -769,8 +769,8 @@ pub const Logger = struct {
     /// Checks if async logging is enabled and running.
     /// Thread-safe: Uses mutex for concurrent access protection.
     pub fn isAsyncEnabled(self: *Logger) bool {
-        self.mutex.lockShared();
-        defer self.mutex.unlockShared();
+        self.mutex.lockSharedUncancelable(Utils.io());
+        defer self.mutex.unlockShared(Utils.io());
 
         if (self.async_logger) |al| {
             return al.running.load(.monotonic);
@@ -781,24 +781,24 @@ pub const Logger = struct {
     /// Enables auto-flush for all logging operations.
     /// Thread-safe: Uses mutex for concurrent access protection.
     pub fn enableAutoFlush(self: *Logger) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.config.auto_flush = true;
     }
 
     /// Disables auto-flush for all logging operations.
     /// Thread-safe: Uses mutex for concurrent access protection.
     pub fn disableAutoFlush(self: *Logger) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.config.auto_flush = false;
     }
 
     /// Checks if auto-flush is enabled.
     /// Thread-safe: Uses mutex for concurrent access protection.
     pub fn isAutoFlushEnabled(self: *Logger) bool {
-        self.mutex.lockShared();
-        defer self.mutex.unlockShared();
+        self.mutex.lockSharedUncancelable(Utils.io());
+        defer self.mutex.unlockShared(Utils.io());
         return self.config.auto_flush;
     }
 
@@ -815,8 +815,8 @@ pub const Logger = struct {
     /// Returns:
     ///     A pointer to the Sink, or null if the index is out of bounds.
     pub fn getSink(self: *Logger, id: usize) ?*Sink {
-        self.mutex.lockShared();
-        defer self.mutex.unlockShared();
+        self.mutex.lockSharedUncancelable(Utils.io());
+        defer self.mutex.unlockShared(Utils.io());
 
         if (id < self.sinks.items.len) {
             return self.sinks.items[id];
@@ -833,8 +833,8 @@ pub const Logger = struct {
     /// Returns:
     ///     The sink stats, or null if the index is out of bounds.
     pub fn getSinkStats(self: *Logger, id: usize) ?Sink.SinkStats {
-        self.mutex.lockShared();
-        defer self.mutex.unlockShared();
+        self.mutex.lockSharedUncancelable(Utils.io());
+        defer self.mutex.unlockShared(Utils.io());
 
         if (id < self.sinks.items.len) {
             return self.sinks.items[id].stats;
@@ -845,8 +845,8 @@ pub const Logger = struct {
     /// Checks if a sink is enabled by index.
     /// Thread-safe: Uses mutex for concurrent access protection.
     pub fn isSinkEnabled(self: *Logger, id: usize) bool {
-        self.mutex.lockShared();
-        defer self.mutex.unlockShared();
+        self.mutex.lockSharedUncancelable(Utils.io());
+        defer self.mutex.unlockShared(Utils.io());
 
         if (id < self.sinks.items.len) {
             return self.sinks.items[id].enabled;
@@ -855,8 +855,8 @@ pub const Logger = struct {
     }
 
     pub fn bind(self: *Logger, key: []const u8, value: std.json.Value) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.context.getPtr(key)) |v_ptr| {
             v_ptr.* = value;
@@ -867,8 +867,8 @@ pub const Logger = struct {
     }
 
     pub fn unbind(self: *Logger, key: []const u8) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.context.fetchRemove(key)) |kv| {
             self.allocator.free(kv.key);
@@ -876,8 +876,8 @@ pub const Logger = struct {
     }
 
     pub fn clearBindings(self: *Logger) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         var it = self.context.iterator();
         while (it.next()) |entry| {
@@ -897,8 +897,8 @@ pub const Logger = struct {
     /// Returns:
     ///     error.LevelAlreadyExists if level name already exists.
     pub fn addCustomLevel(self: *Logger, name: []const u8, priority: u8, color: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.custom_levels.contains(name)) {
             return error.LevelAlreadyExists;
@@ -919,8 +919,8 @@ pub const Logger = struct {
     /// Updates an existing custom log level, or adds it if it doesn't exist.
     /// Use this when you want to allow updates.
     pub fn updateCustomLevel(self: *Logger, name: []const u8, priority: u8, color: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.custom_levels.getPtr(name)) |level_ptr| {
             // Update existing level
@@ -945,21 +945,21 @@ pub const Logger = struct {
 
     /// Checks if a custom level with the given name exists.
     pub fn hasCustomLevel(self: *Logger, name: []const u8) bool {
-        self.mutex.lockShared();
-        defer self.mutex.unlockShared();
+        self.mutex.lockSharedUncancelable(Utils.io());
+        defer self.mutex.unlockShared(Utils.io());
         return self.custom_levels.contains(name);
     }
 
     /// Returns the count of custom levels.
     pub fn getCustomLevelCount(self: *Logger) usize {
-        self.mutex.lockShared();
-        defer self.mutex.unlockShared();
+        self.mutex.lockSharedUncancelable(Utils.io());
+        defer self.mutex.unlockShared(Utils.io());
         return self.custom_levels.count();
     }
 
     pub fn removeCustomLevel(self: *Logger, name: []const u8) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.custom_levels.fetchRemove(name)) |kv| {
             self.allocator.free(kv.value.name);
@@ -968,75 +968,75 @@ pub const Logger = struct {
     }
 
     pub fn setLogCallback(self: *Logger, callback: *const fn (*const Record) anyerror!void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.log_callback = callback;
     }
 
     pub fn setColorCallback(self: *Logger, callback: *const fn (Level, []const u8) []const u8) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.color_callback = callback;
     }
 
     /// Sets the callback for when a record is successfully logged.
     pub fn setLoggedCallback(self: *Logger, callback: *const fn (Level, []const u8, *const Record) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_record_logged = callback;
     }
 
     /// Sets the callback for when a record is filtered/dropped.
     pub fn setFilteredCallback(self: *Logger, callback: *const fn ([]const u8, *const Record) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_record_filtered = callback;
     }
 
     /// Sets the callback for when a sink encounters an error.
     pub fn setSinkErrorCallback(self: *Logger, callback: *const fn ([]const u8, []const u8) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_sink_error = callback;
     }
 
     /// Sets the callback for logger initialization.
     pub fn setInitializedCallback(self: *Logger, callback: *const fn (*const LoggerStats) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_logger_initialized = callback;
     }
 
     /// Sets the callback for logger destruction.
     pub fn setDestroyedCallback(self: *Logger, callback: *const fn (*const LoggerStats) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_logger_destroyed = callback;
     }
 
     /// Returns logger statistics for monitoring and diagnostics.
     pub fn getStats(self: *Logger) LoggerStats {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         return self.stats;
     }
 
     pub fn enable(self: *Logger) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.enabled = true;
     }
 
     pub fn disable(self: *Logger) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.enabled = false;
     }
 
     pub fn flush(self: *Logger) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         try self.flushInternal();
     }
 
@@ -1050,8 +1050,8 @@ pub const Logger = struct {
     }
 
     pub fn setModuleLevel(self: *Logger, module: []const u8, level: Level) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.module_levels.getPtr(module)) |level_ptr| {
             level_ptr.* = level;
@@ -1062,8 +1062,8 @@ pub const Logger = struct {
     }
 
     pub fn getModuleLevel(self: *Logger, module: []const u8) ?Level {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         return self.module_levels.get(module);
     }
 
@@ -1110,10 +1110,10 @@ pub const Logger = struct {
         const logger = task_ctx.logger;
 
         // Snapshot sinks to avoid holding lock during write
-        logger.mutex.lock();
+        logger.mutex.lockUncancelable(Utils.io());
         var sinks_snapshot: std.ArrayList(*Sink) = .empty;
         sinks_snapshot.appendSlice(logger.allocator, logger.sinks.items) catch {};
-        logger.mutex.unlock();
+        logger.mutex.unlock(Utils.io());
         defer sinks_snapshot.deinit(logger.allocator);
 
         for (sinks_snapshot.items) |sink| {
@@ -1148,8 +1148,8 @@ pub const Logger = struct {
         // Optimization: Use Shared lock if arena is not used, allowing concurrent logging.
         // If arena is used, we must use exclusive lock because arena allocation modifies state.
         const use_arena = self.config.use_arena_allocator;
-        if (use_arena) self.mutex.lock() else self.mutex.lockShared();
-        defer if (use_arena) self.mutex.unlock() else self.mutex.unlockShared();
+        if (use_arena) self.mutex.lockUncancelable(Utils.io()) else self.mutex.lockSharedUncancelable(Utils.io());
+        defer if (use_arena) self.mutex.unlock(Utils.io()) else self.mutex.unlockShared(Utils.io());
 
         if (use_arena) {
             self.maybeResetArenaBeforeRecord();
@@ -1216,11 +1216,11 @@ pub const Logger = struct {
             if (allocator.create(std.builtin.StackTrace)) |st| {
                 // Allocate a larger buffer to be safe
                 if (allocator.alloc(usize, 64)) |addresses| {
+                    const captured = std.debug.captureCurrentStackTrace(.{}, addresses);
                     st.* = .{
                         .instruction_addresses = addresses,
-                        .index = 0,
+                        .index = captured.return_addresses.len,
                     };
-                    std.debug.captureStackTrace(null, st);
 
                     record.stack_trace = st;
                     record.owned_stack_trace = st;
@@ -1381,8 +1381,8 @@ pub const Logger = struct {
     pub fn logError(self: *Logger, message: []const u8, err_val: anyerror) !void {
         if (!self.enabled) return;
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         var record = Record.init(self.allocator, .err, message);
         defer record.deinit();
@@ -1411,7 +1411,7 @@ pub const Logger = struct {
     /// Arguments:
     ///     level: The log level.
     ///     message: The log message.
-    ///     start_time: The start timestamp from std.time.nanoTimestamp().
+    ///     start_time: The start timestamp from Utils.currentNanos().
     ///
     /// Returns:
     ///     The duration in nanoseconds.
@@ -1421,8 +1421,8 @@ pub const Logger = struct {
 
         if (!self.enabled) return duration;
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         var record = Record.init(self.allocator, level, message);
         defer record.deinit();
@@ -1462,10 +1462,10 @@ pub const Logger = struct {
         defer diag.deinit(alloc);
 
         // Build message using default structure (ASCII-safe)
-        var msg = std.ArrayList(u8){};
-        defer msg.deinit(alloc);
+        var msg = std.Io.Writer.Allocating.init(alloc);
+        defer msg.deinit();
 
-        var w = msg.writer(alloc);
+        const w = &msg.writer;
         try w.print(
             "[DIAGNOSTICS] os={s} arch={s} cpu={s} cores={d}",
             .{ diag.os_tag, diag.arch, diag.cpu_model, diag.logical_cores },
@@ -1488,10 +1488,10 @@ pub const Logger = struct {
         }
 
         // Log with context data for structured formatting support
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
-        var record = Record.init(self.scratchAllocator(), .info, msg.items);
+        var record = Record.init(self.scratchAllocator(), .info, msg.written());
         defer record.deinit();
 
         if (src) |s| {
@@ -1613,8 +1613,8 @@ pub const Logger = struct {
     ) !void {
         if (!self.enabled) return;
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         // Check level filtering
         var effective_min_level = self.config.level;
@@ -1884,8 +1884,8 @@ pub const SpanContext = struct {
             _ = try self.logger.logTimed(.debug, msg, self.start_time);
         }
 
-        self.logger.mutex.lock();
-        defer self.logger.mutex.unlock();
+        self.logger.mutex.lockUncancelable(Utils.io());
+        defer self.logger.mutex.unlock(Utils.io());
 
         if (self.logger.span_id) |current| {
             self.logger.allocator.free(current);
@@ -1897,8 +1897,8 @@ pub const SpanContext = struct {
 
     /// Ends the span without logging.
     pub fn endSilent(self: *SpanContext) void {
-        self.logger.mutex.lock();
-        defer self.logger.mutex.unlock();
+        self.logger.mutex.lockUncancelable(Utils.io());
+        defer self.logger.mutex.unlock(Utils.io());
 
         if (self.logger.span_id) |current| {
             self.logger.allocator.free(current);
@@ -2401,7 +2401,7 @@ test "distributed logger child and module helpers" {
 }
 
 test "logger supports GeneralPurposeAllocator" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
 
     var config = Config.default();

--- a/src/logly.zig
+++ b/src/logly.zig
@@ -21,7 +21,7 @@
 //! const logly = @import("logly");
 //!
 //! pub fn main() !void {
-//!     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+//!     var gpa = std.heap.DebugAllocator(.{}){};
 //!     defer _ = gpa.deinit();
 //!     const allocator = gpa.allocator();
 //!
@@ -353,35 +353,8 @@ pub const Terminal = struct {
         const builtin = @import("builtin");
         if (builtin.os.tag != .windows) return true;
 
-        const windows = std.os.windows;
-        const kernel32 = windows.kernel32;
-
-        const stdout_handle = kernel32.GetStdHandle(windows.STD_OUTPUT_HANDLE);
-        if (stdout_handle == windows.INVALID_HANDLE_VALUE) return false;
-
-        const handle = stdout_handle orelse return false;
-
-        var mode: windows.DWORD = 0;
-        if (kernel32.GetConsoleMode(handle, &mode) == 0) {
-            return false;
-        }
-
-        const ENABLE_VIRTUAL_TERMINAL_PROCESSING: windows.DWORD = 0x0004;
-        const new_mode = mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
-        if (kernel32.SetConsoleMode(handle, new_mode) == 0) {
-            return false;
-        }
-
-        // Enable for stderr as well
-        const stderr_handle = kernel32.GetStdHandle(windows.STD_ERROR_HANDLE);
-        if (stderr_handle != windows.INVALID_HANDLE_VALUE) {
-            if (stderr_handle) |stderr| {
-                var stderr_mode: windows.DWORD = 0;
-                if (kernel32.GetConsoleMode(stderr, &stderr_mode) != 0) {
-                    _ = kernel32.SetConsoleMode(stderr, stderr_mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
-                }
-            }
-        }
+        std.Io.File.stdout().enableAnsiEscapeCodes(Utils.io()) catch return false;
+        std.Io.File.stderr().enableAnsiEscapeCodes(Utils.io()) catch {};
 
         return true;
     }

--- a/src/metrics.zig
+++ b/src/metrics.zig
@@ -260,7 +260,7 @@ pub const Metrics = struct {
     pub const MetricsConfig = Config.MetricsConfig;
 
     /// Mutual exclusion for thread-safe operations.
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = std.Io.Mutex.init,
     /// Metrics configuration.
     config: MetricsConfig = .{},
 
@@ -385,29 +385,29 @@ pub const Metrics = struct {
 
     /// Sets the callback for record logged events.
     pub fn setRecordLoggedCallback(self: *Metrics, callback: *const fn (Level, u64) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_record_logged = callback;
     }
 
     /// Sets the callback for metrics snapshot events.
     pub fn setSnapshotCallback(self: *Metrics, callback: *const fn (*const Snapshot) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_metrics_snapshot = callback;
     }
 
     /// Sets the callback for threshold exceeded events.
     pub fn setThresholdCallback(self: *Metrics, callback: *const fn (MetricType, u64, u64) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_threshold_exceeded = callback;
     }
 
     /// Sets the callback for error detected events.
     pub fn setErrorCallback(self: *Metrics, callback: *const fn (ErrorEvent, u64) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_error_detected = callback;
     }
 
@@ -552,8 +552,8 @@ pub const Metrics = struct {
     /// Returns:
     ///     The index of the sink in the metrics array.
     pub fn addSink(self: *Metrics, name: []const u8) !usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         const owned_name = try self.allocator.dupe(u8, name);
         try self.sink_metrics.append(self.allocator, .{ .name = owned_name });
@@ -615,8 +615,8 @@ pub const Metrics = struct {
 
         // Store in history if configured
         if (self.config.history_size > 0) {
-            self.mutex.lock();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(Utils.io());
+            defer self.mutex.unlock(Utils.io());
 
             // Remove oldest if at capacity
             if (self.history.items.len >= self.config.history_size) {
@@ -703,7 +703,8 @@ pub const Metrics = struct {
         const snapshot = self.getSnapshot();
         var buf: std.ArrayList(u8) = .empty;
         errdefer buf.deinit(allocator);
-        const writer = buf.writer(allocator);
+        var list_writer = Utils.ArrayListWriter.init(&buf, allocator);
+        const writer = &list_writer.writer;
 
         try writer.writeAll("# HELP logly_records_total Total log records\n");
         try writer.writeAll("# TYPE logly_records_total counter\n");
@@ -906,7 +907,8 @@ pub const Metrics = struct {
         const snapshot = self.getSnapshot();
         var buf: std.ArrayList(u8) = .empty;
         errdefer buf.deinit(allocator);
-        const writer = buf.writer(allocator);
+        var list_writer = Utils.ArrayListWriter.init(&buf, allocator);
+        const writer = &list_writer.writer;
 
         try writer.writeAll("Level Breakdown:");
         var has_levels = false;

--- a/src/network.zig
+++ b/src/network.zig
@@ -158,9 +158,9 @@ pub fn formatSyslog(
     const priority = (@as(u8, @intFromEnum(facility)) * 8) + @as(u8, @intFromEnum(severity));
     const timestamp = Utils.currentSeconds();
 
-    var res = std.ArrayList(u8){};
-    errdefer res.deinit(allocator);
-    const w = res.writer(allocator);
+    var res = std.Io.Writer.Allocating.init(allocator);
+    errdefer res.deinit();
+    const w = &res.writer;
 
     try w.writeByte('<');
     try Utils.writeInt(w, priority);
@@ -174,7 +174,7 @@ pub fn formatSyslog(
     try w.writeAll(message);
     try w.writeByte('\n');
 
-    return res.toOwnedSlice(allocator);
+    return res.toOwnedSlice();
 }
 
 /// Alias for formatSyslog
@@ -182,8 +182,8 @@ pub const syslogFormat = formatSyslog;
 pub const formatAsSyslog = formatSyslog;
 
 /// Connects to a TCP host specified by a URI string (e.g., "tcp://127.0.0.1:8080").
-/// Returns a std.net.Stream.
-pub fn connectTcp(allocator: std.mem.Allocator, uri: []const u8) !std.net.Stream {
+/// Returns a std.Io.net.Stream.
+pub fn connectTcp(allocator: std.mem.Allocator, uri: []const u8) !std.Io.net.Stream {
     if (!std.mem.startsWith(u8, uri, "tcp://")) return NetworkError.InvalidUri;
     const address_part = uri[6..];
 
@@ -192,7 +192,9 @@ pub fn connectTcp(allocator: std.mem.Allocator, uri: []const u8) !std.net.Stream
         const port_str = address_part[colon_idx + 1 ..];
         const port = std.fmt.parseInt(u16, port_str, 10) catch return NetworkError.InvalidUri;
 
-        const stream = std.net.tcpConnectToHost(allocator, host, port) catch return NetworkError.ConnectionFailed;
+        _ = allocator;
+        const host_name = std.Io.net.HostName.init(host) catch return NetworkError.InvalidUri;
+        const stream = host_name.connect(Utils.io(), port, .{ .mode = .stream, .protocol = .tcp }) catch return NetworkError.ConnectionFailed;
         _ = stats.connections_made.fetchAdd(1, .monotonic);
         return stream;
     }
@@ -205,7 +207,7 @@ pub const connect = connectTcp;
 
 /// Creates a UDP socket connected to a host specified by a URI string (e.g., "udp://127.0.0.1:514").
 /// Returns a tuple of (socket, address).
-pub fn createUdpSocket(allocator: std.mem.Allocator, uri: []const u8) !struct { socket: std.posix.socket_t, address: std.net.Address } {
+pub fn createUdpSocket(allocator: std.mem.Allocator, uri: []const u8) !struct { socket: std.Io.net.Socket, address: std.Io.net.IpAddress } {
     if (!std.mem.startsWith(u8, uri, "udp://")) return NetworkError.InvalidUri;
     const address_part = uri[6..];
 
@@ -214,12 +216,14 @@ pub fn createUdpSocket(allocator: std.mem.Allocator, uri: []const u8) !struct { 
         const port_str = address_part[colon_idx + 1 ..];
         const port = std.fmt.parseInt(u16, port_str, 10) catch return NetworkError.InvalidUri;
 
-        const list = std.net.getAddressList(allocator, host, port) catch return NetworkError.AddressResolutionError;
-        defer list.deinit();
-
-        if (list.addrs.len > 0) {
-            const address = list.addrs[0];
-            const socket = std.posix.socket(address.any.family, std.posix.SOCK.DGRAM, 0) catch return NetworkError.SocketCreationError;
+        _ = allocator;
+        const address = std.Io.net.IpAddress.parse(host, port) catch return NetworkError.AddressResolutionError;
+        {
+            const local_address = switch (address) {
+                .ip4 => std.Io.net.IpAddress.parse("0.0.0.0", 0) catch unreachable,
+                .ip6 => std.Io.net.IpAddress.parse("::", 0) catch unreachable,
+            };
+            const socket = local_address.bind(Utils.io(), .{ .mode = .dgram, .protocol = .udp }) catch return NetworkError.SocketCreationError;
             _ = stats.connections_made.fetchAdd(1, .monotonic);
             return .{ .socket = socket, .address = address };
         }
@@ -231,12 +235,12 @@ pub fn createUdpSocket(allocator: std.mem.Allocator, uri: []const u8) !struct { 
 pub const udpSocket = createUdpSocket;
 
 /// Sends data via UDP socket.
-pub fn sendUdp(socket: std.posix.socket_t, address: std.net.Address, data: []const u8) !void {
-    const sent = std.posix.sendto(socket, data, 0, &address.any, address.getOsSockLen()) catch {
+pub fn sendUdp(socket: std.Io.net.Socket, address: std.Io.net.IpAddress, data: []const u8) !void {
+    socket.send(Utils.io(), &address, data) catch {
         _ = stats.errors.fetchAdd(1, .monotonic);
         return NetworkError.SendFailed;
     };
-    _ = stats.bytes_sent.fetchAdd(@truncate(sent), .monotonic);
+    _ = stats.bytes_sent.fetchAdd(@truncate(data.len), .monotonic);
     _ = stats.messages_sent.fetchAdd(1, .monotonic);
 }
 
@@ -247,7 +251,7 @@ pub const sendToUdp = sendUdp;
 /// Fetches a JSON response from a URL.
 /// Returns the parsed JSON value (caller must deinit).
 pub fn fetchJson(allocator: std.mem.Allocator, url: []const u8, headers: []const http.Header) !std.json.Parsed(std.json.Value) {
-    var client = http.Client{ .allocator = allocator };
+    var client = http.Client{ .allocator = allocator, .io = Utils.io() };
     defer client.deinit();
 
     var req = try client.request(.GET, try std.Uri.parse(url), .{
@@ -279,7 +283,8 @@ pub fn fetchJson(allocator: std.mem.Allocator, url: []const u8, headers: []const
     var body = std.ArrayList(u8).initCapacity(allocator, Constants.BufferSizes.message) catch return NetworkError.ReadError;
     defer body.deinit(allocator);
 
-    const writer = body.writer(allocator);
+    var body_writer = Utils.ArrayListWriter.init(&body, allocator);
+    const writer = &body_writer.writer;
     var buf: [Constants.BufferSizes.message]u8 = undefined;
     while (true) {
         const n = reader.readSliceShort(&buf) catch return NetworkError.ReadError;
@@ -364,36 +369,29 @@ pub const LogServer = struct {
     pub const listenUdp = startUdp;
 
     fn tcpWorker(self: *LogServer, port: u16, callback: *const fn ([]const u8) void) void {
-        const address = std.net.Address.parseIp("0.0.0.0", port) catch return;
-        const tpe: u32 = std.posix.SOCK.STREAM;
-        const protocol = std.posix.IPPROTO.TCP;
-
-        const listener = std.posix.socket(address.any.family, tpe, protocol) catch return;
-        defer std.posix.close(listener);
-
-        std.posix.setsockopt(listener, std.posix.SOL.SOCKET, std.posix.SO.REUSEADDR, &std.mem.toBytes(@as(c_int, 1))) catch {};
-        std.posix.bind(listener, &address.any, address.getOsSockLen()) catch return;
-        std.posix.listen(listener, 128) catch return;
+        const io = Utils.io();
+        const address = std.Io.net.IpAddress.parse("0.0.0.0", port) catch return;
+        var server = address.listen(io, .{ .reuse_address = true }) catch return;
+        defer server.deinit(io);
 
         while (self.running.load(.monotonic)) {
-            var client_address: std.net.Address = undefined;
-            var client_address_len: std.posix.socklen_t = @sizeOf(std.net.Address);
+            const stream = server.accept(io) catch continue;
 
-            const socket = std.posix.accept(listener, &client_address.any, &client_address_len, 0) catch continue;
-
-            const thread = std.Thread.spawn(.{}, tcpClientHandler, .{ self, socket, callback }) catch {
-                std.posix.close(socket);
+            const thread = std.Thread.spawn(.{}, tcpClientHandler, .{ self, stream, callback }) catch {
+                stream.close(io);
                 continue;
             };
             thread.detach();
         }
     }
 
-    fn tcpClientHandler(self: *LogServer, socket: std.posix.socket_t, callback: *const fn ([]const u8) void) void {
-        defer std.posix.close(socket);
+    fn tcpClientHandler(self: *LogServer, stream: std.Io.net.Stream, callback: *const fn ([]const u8) void) void {
+        const io = Utils.io();
+        defer stream.close(io);
         var buf: [Constants.NetworkConstants.tcp_buffer_size]u8 = undefined;
+        var reader = stream.reader(io, &buf);
         while (self.running.load(.monotonic)) {
-            const read = std.posix.recv(socket, &buf, 0) catch break;
+            const read = reader.interface.readSliceShort(&buf) catch break;
             if (read == 0) break;
             _ = self.messages_received.fetchAdd(1, .monotonic);
             callback(buf[0..read]);
@@ -401,22 +399,17 @@ pub const LogServer = struct {
     }
 
     fn udpWorker(self: *LogServer, port: u16, callback: *const fn ([]const u8) void) void {
-        const address = std.net.Address.parseIp("0.0.0.0", port) catch return;
-        const socket = std.posix.socket(address.any.family, std.posix.SOCK.DGRAM, std.posix.IPPROTO.UDP) catch return;
-        defer std.posix.close(socket);
-
-        std.posix.setsockopt(socket, std.posix.SOL.SOCKET, std.posix.SO.REUSEADDR, &std.mem.toBytes(@as(c_int, 1))) catch {};
-        std.posix.bind(socket, &address.any, address.getOsSockLen()) catch return;
+        const io = Utils.io();
+        const address = std.Io.net.IpAddress.parse("0.0.0.0", port) catch return;
+        const socket = address.bind(io, .{ .mode = .dgram, .protocol = .udp }) catch return;
+        defer socket.close(io);
 
         var buf: [Constants.NetworkConstants.udp_max_packet]u8 = undefined;
         while (self.running.load(.monotonic)) {
-            var client_address: std.net.Address = undefined;
-            var client_address_len: std.posix.socklen_t = @sizeOf(std.net.Address);
-
-            const read = std.posix.recvfrom(socket, &buf, 0, &client_address.any, &client_address_len) catch continue;
-            if (read == 0) continue;
+            const message = socket.receive(io, &buf) catch continue;
+            if (message.data.len == 0) continue;
             _ = self.messages_received.fetchAdd(1, .monotonic);
-            callback(buf[0..read]);
+            callback(message.data);
         }
     }
 };

--- a/src/redactor.zig
+++ b/src/redactor.zig
@@ -205,7 +205,7 @@ pub const Redactor = struct {
     /// Redactor statistics.
     stats: RedactorStats = .{},
     /// Mutex for thread-safe operations.
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = std.Io.Mutex.init,
 
     /// Callback invoked when redaction is applied.
     /// Parameters: (original_length: u64, redacted_length: u64, redaction_type: u32)
@@ -344,43 +344,43 @@ pub const Redactor = struct {
 
     /// Sets the callback for redaction applied events.
     pub fn setCallback(self: *Redactor, callback: *const fn (u64, u64, u32) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_redaction_applied = callback;
     }
 
     /// Sets the callback for redaction applied events.
     pub fn setRedactionAppliedCallback(self: *Redactor, callback: *const fn (u64, u64, u32) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_redaction_applied = callback;
     }
 
     /// Sets the callback for pattern matched events.
     pub fn setPatternMatchedCallback(self: *Redactor, callback: *const fn ([]const u8, []const u8) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_pattern_matched = callback;
     }
 
     /// Sets the callback for redactor initialization.
     pub fn setInitializedCallback(self: *Redactor, callback: *const fn (*const RedactorStats) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_redactor_initialized = callback;
     }
 
     /// Sets the callback for redaction errors.
     pub fn setErrorCallback(self: *Redactor, callback: *const fn ([]const u8) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_redaction_error = callback;
     }
 
     /// Returns redactor statistics.
     pub fn getStats(self: *Redactor) RedactorStats {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         return self.stats;
     }
@@ -391,8 +391,8 @@ pub const Redactor = struct {
     ///     field_name: The name of the field to redact.
     ///     redaction_type: The type of redaction to apply.
     pub fn addField(self: *Redactor, field_name: []const u8, redaction_type: RedactionType) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.fields.getPtr(field_name)) |existing| {
             existing.* = redaction_type;
@@ -429,8 +429,8 @@ pub const Redactor = struct {
         pattern: []const u8,
         replacement: []const u8,
     ) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         try self.patterns.append(self.allocator, .{
             .name = try self.allocator.dupe(u8, name),
@@ -456,8 +456,8 @@ pub const Redactor = struct {
     ///
     /// Returns true when a matching field was removed.
     pub fn removeField(self: *Redactor, field_name: []const u8) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.fields.fetchRemove(field_name)) |entry| {
             self.allocator.free(entry.key);
@@ -489,8 +489,8 @@ pub const Redactor = struct {
     ///
     /// Returns the number of removed patterns.
     pub fn removePatternByName(self: *Redactor, name: []const u8) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         var removed: usize = 0;
         var i = self.patterns.items.len;

--- a/src/rotation.zig
+++ b/src/rotation.zig
@@ -272,7 +272,7 @@ pub const Rotation = struct {
     /// Rotation statistics.
     stats: RotationStats = .{},
     /// Mutex for thread-safe operations.
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = std.Io.Mutex.init,
 
     /// Initializes rotation with optional interval, size limit, and retention count.
     pub fn init(
@@ -443,7 +443,7 @@ pub const Rotation = struct {
     }
 
     /// Computes rotation reason without taking locks.
-    fn computeRotationReason(self: *Rotation, file_ptr: *std.fs.File, now: i64) ?RotationReason {
+    fn computeRotationReason(self: *Rotation, file_ptr: *std.Io.File, now: i64) ?RotationReason {
         var by_interval = false;
         var by_size = false;
 
@@ -452,7 +452,7 @@ pub const Rotation = struct {
         }
 
         if (self.size_limit) |limit| {
-            if (file_ptr.stat()) |stat| {
+            if (file_ptr.stat(Utils.io())) |stat| {
                 by_size = stat.size >= limit;
             } else |_| {
                 // Ignore stat errors and retry on next check.
@@ -466,15 +466,15 @@ pub const Rotation = struct {
     }
 
     /// Returns why rotation would occur for the current file state.
-    pub fn getRotationReason(self: *Rotation, file_ptr: *std.fs.File) ?RotationReason {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+    pub fn getRotationReason(self: *Rotation, file_ptr: *std.Io.File) ?RotationReason {
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         return self.computeRotationReason(file_ptr, Utils.currentSeconds());
     }
 
     /// Returns true when rotation conditions are currently met.
-    pub fn shouldRotate(self: *Rotation, file_ptr: *std.fs.File) bool {
+    pub fn shouldRotate(self: *Rotation, file_ptr: *std.Io.File) bool {
         return self.getRotationReason(file_ptr) != null;
     }
 
@@ -489,24 +489,24 @@ pub const Rotation = struct {
     }
 
     /// Forces immediate rotation regardless of current interval/size checks.
-    pub fn forceRotate(self: *Rotation, file_ptr: *std.fs.File) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+    pub fn forceRotate(self: *Rotation, file_ptr: *std.Io.File) !void {
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         try self.performRotation(file_ptr);
     }
 
     /// Returns the next rotated path without mutating state.
     pub fn previewNextPath(self: *Rotation) ![]u8 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         return self.generateRotatedPath();
     }
 
     /// Performs rotation when interval and/or size triggers are met.
-    pub fn checkAndRotate(self: *Rotation, file_ptr: *std.fs.File) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+    pub fn checkAndRotate(self: *Rotation, file_ptr: *std.Io.File) !void {
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         const now = Utils.currentSeconds();
 
@@ -609,7 +609,7 @@ pub const Rotation = struct {
     pub const rotateIfNeeded = checkAndRotate;
     pub const maybeRotate = checkAndRotate;
 
-    fn performRotation(self: *Rotation, file_ptr: *std.fs.File) !void {
+    fn performRotation(self: *Rotation, file_ptr: *std.Io.File) !void {
         const start_time = Utils.currentMillis();
 
         // 1. Generate new filename
@@ -620,14 +620,14 @@ pub const Rotation = struct {
         if (self.archive_dir) |_| {
             const dir = std.fs.path.dirname(rotated_path);
             if (dir) |d| {
-                std.fs.cwd().makePath(d) catch {};
+                std.Io.Dir.cwd().createDirPath(Utils.io(), d) catch {};
             }
         }
 
         if (self.on_rotation_start) |cb| cb(self.base_path, rotated_path);
 
         // 2. Close current file
-        file_ptr.close();
+        file_ptr.close(Utils.io());
 
         // 3. Rename current file to rotated path
         // For index strategy, we might need to shift existing files first
@@ -635,15 +635,14 @@ pub const Rotation = struct {
             try self.shiftIndexFiles();
         }
 
-        std.fs.cwd().rename(self.base_path, rotated_path) catch |err| {
+        std.Io.Dir.cwd().rename(self.base_path, std.Io.Dir.cwd(), rotated_path, Utils.io()) catch |err| {
             // Try to reopen functionality if rename fails
-            file_ptr.* = try std.fs.cwd().createFile(self.base_path, .{ .read = true, .truncate = false }); // Append mode effectively
-            file_ptr.seekFromEnd(0) catch {};
+            file_ptr.* = try std.Io.Dir.cwd().createFile(Utils.io(), self.base_path, .{ .read = true, .truncate = false }); // Append mode effectively
             return err;
         };
 
         // 4. Re-open log file (fresh)
-        file_ptr.* = try std.fs.cwd().createFile(self.base_path, .{
+        file_ptr.* = try std.Io.Dir.cwd().createFile(Utils.io(), self.base_path, .{
             .read = true,
             .truncate = true,
         });
@@ -676,7 +675,7 @@ pub const Rotation = struct {
 
                 // If successful and keep_original is false, remove uncompressed rotated file
                 if (!self.keep_original) {
-                    std.fs.cwd().deleteFile(rotated_path) catch {};
+                    std.Io.Dir.cwd().deleteFile(Utils.io(), rotated_path) catch {};
                 }
 
                 self.allocator.free(final_path);
@@ -723,9 +722,9 @@ pub const Rotation = struct {
                 const m = (ds.secs % @as(u64, Constants.TimeConstants.seconds_per_hour)) / @as(u64, Constants.TimeConstants.seconds_per_minute);
                 const s = ds.secs % @as(u64, Constants.TimeConstants.seconds_per_minute);
 
-                var res: std.ArrayList(u8) = .empty;
-                errdefer res.deinit(self.allocator);
-                const w = res.writer(self.allocator);
+                var res = std.Io.Writer.Allocating.init(self.allocator);
+                errdefer res.deinit();
+                const w = &res.writer;
                 try w.writeAll(base_name);
                 try w.writeByte('.');
                 try Utils.writeFilenameSafe(w, Utils.TimeComponents{
@@ -736,7 +735,7 @@ pub const Rotation = struct {
                     .minute = m,
                     .second = s,
                 });
-                name_buf = try res.toOwnedSlice(self.allocator);
+                name_buf = try res.toOwnedSlice();
             },
             .index => {
                 // For index strategy, the immediate rotated file is always .1
@@ -759,27 +758,27 @@ pub const Rotation = struct {
 
                     // Optimization: Pre-allocate buffer to minimize reallocations
                     // Estimate size: format length + extra space for replacements (timestamp, etc.)
-                    var res = std.ArrayList(u8){};
-                    try res.ensureTotalCapacity(self.allocator, fmt.len + 64);
-                    defer res.deinit(self.allocator);
+                    var res = try std.Io.Writer.Allocating.initCapacity(self.allocator, fmt.len + 64);
+                    errdefer res.deinit();
+                    const w = &res.writer;
 
                     var i: usize = 0;
                     while (i < fmt.len) {
                         if (fmt[i] == '{') {
                             const end = std.mem.indexOfPos(u8, fmt, i, "}") orelse {
-                                try res.append(self.allocator, fmt[i]);
+                                try w.writeByte(fmt[i]);
                                 i += 1;
                                 continue;
                             };
                             const tag = fmt[i + 1 .. end];
                             if (std.mem.eql(u8, tag, "base")) {
-                                try res.appendSlice(self.allocator, stem);
+                                try w.writeAll(stem);
                             } else if (std.mem.eql(u8, tag, "ext")) {
-                                try res.appendSlice(self.allocator, ext);
+                                try w.writeAll(ext);
                             } else if (std.mem.eql(u8, tag, "timestamp")) {
-                                try Utils.writeInt(res.writer(self.allocator), now);
+                                try Utils.writeInt(w, now);
                             } else if (std.mem.eql(u8, tag, "date")) {
-                                try Utils.writeIsoDate(res.writer(self.allocator), Utils.TimeComponents{
+                                try Utils.writeIsoDate(w, Utils.TimeComponents{
                                     .year = yd.year,
                                     .month = md.month.numeric(),
                                     .day = md.day_index + 1,
@@ -788,7 +787,7 @@ pub const Rotation = struct {
                                     .second = s,
                                 });
                             } else if (std.mem.eql(u8, tag, "time")) {
-                                try Utils.writeIsoTime(res.writer(self.allocator), Utils.TimeComponents{
+                                try Utils.writeIsoTime(w, Utils.TimeComponents{
                                     .year = yd.year,
                                     .month = md.month.numeric(),
                                     .day = md.day_index + 1,
@@ -797,7 +796,7 @@ pub const Rotation = struct {
                                     .second = s,
                                 });
                             } else if (std.mem.eql(u8, tag, "iso")) {
-                                try Utils.writeIsoDateTime(res.writer(self.allocator), Utils.TimeComponents{
+                                try Utils.writeIsoDateTime(w, Utils.TimeComponents{
                                     .year = yd.year,
                                     .month = md.month.numeric(),
                                     .day = md.day_index + 1,
@@ -807,15 +806,15 @@ pub const Rotation = struct {
                                 });
                             } else {
                                 // Granular date format parsing via shared utility
-                                try Utils.formatDatePattern(res.writer(self.allocator), tag, yd.year, md.month.numeric(), md.day_index + 1, h, m, s, millis);
+                                try Utils.formatDatePattern(w, tag, yd.year, md.month.numeric(), md.day_index + 1, h, m, s, millis);
                             }
                             i = end + 1;
                         } else {
-                            try res.append(self.allocator, fmt[i]);
+                            try w.writeByte(fmt[i]);
                             i += 1;
                         }
                     }
-                    name_buf = try res.toOwnedSlice(self.allocator);
+                    name_buf = try res.toOwnedSlice();
                 } else {
                     // Fallback if custom selected but no format
                     name_buf = try std.fmt.allocPrint(self.allocator, "{s}.{d}", .{ base_name, now });
@@ -853,10 +852,10 @@ pub const Rotation = struct {
             defer self.allocator.free(current_path);
 
             // If file exists
-            if (std.fs.cwd().access(current_path, .{})) |_| {
+            if (std.Io.Dir.cwd().access(Utils.io(), current_path, .{})) |_| {
                 if (i == max) {
                     // Delete overflow
-                    std.fs.cwd().deleteFile(current_path) catch {};
+                    std.Io.Dir.cwd().deleteFile(Utils.io(), current_path) catch {};
                 } else {
                     // Rename to next
                     const next_name = try std.fmt.allocPrint(self.allocator, "{s}.{d}", .{ base_name, i + 1 });
@@ -864,7 +863,7 @@ pub const Rotation = struct {
                     const next_path = try std.fs.path.join(self.allocator, &.{ target_dir, next_name });
                     defer self.allocator.free(next_path);
 
-                    std.fs.cwd().rename(current_path, next_path) catch {};
+                    std.Io.Dir.cwd().rename(current_path, std.Io.Dir.cwd(), next_path, Utils.io()) catch {};
                 }
             } else |_| {}
         }
@@ -874,8 +873,8 @@ pub const Rotation = struct {
         const dir_path = self.archive_dir orelse (std.fs.path.dirname(self.base_path) orelse ".");
         const base_name = std.fs.path.basename(self.base_path);
 
-        var dir = std.fs.cwd().openDir(dir_path, .{ .iterate = true }) catch return;
-        defer dir.close();
+        var dir = std.Io.Dir.cwd().openDir(Utils.io(), dir_path, .{ .iterate = true }) catch return;
+        defer dir.close(Utils.io());
 
         const FileInfo = struct { name: []u8, mtime: i128, is_compressed: bool };
         var files: std.ArrayList(FileInfo) = .empty;
@@ -885,21 +884,21 @@ pub const Rotation = struct {
         }
 
         var iter = dir.iterate();
-        while (try iter.next()) |entry| {
+        while (try iter.next(Utils.io())) |entry| {
             if (entry.kind != .file) continue;
             // Matches base_name and starts with it
             if (std.mem.startsWith(u8, entry.name, base_name) and !std.mem.eql(u8, entry.name, base_name)) {
                 const full_path = try std.fs.path.join(self.allocator, &.{ dir_path, entry.name });
                 defer self.allocator.free(full_path);
 
-                const stat = std.fs.cwd().statFile(full_path) catch continue;
+                const stat = std.Io.Dir.cwd().statFile(Utils.io(), full_path, .{}) catch continue;
 
                 // Check if already compressed
                 const is_compressed = Constants.CompressionExtensions.isCompressed(entry.name);
 
                 // Age check
                 if (self.max_age_seconds) |max_age| {
-                    const age = Utils.currentNanos() - stat.mtime;
+                    const age = Utils.currentNanos() - stat.mtime.toNanoseconds();
                     if (age > max_age * Constants.TimeConstants.ns_per_second) {
                         try self.handleRetentionFile(full_path, is_compressed);
                         continue; // handled, don't add to list
@@ -908,7 +907,7 @@ pub const Rotation = struct {
 
                 try files.append(self.allocator, .{
                     .name = try self.allocator.dupe(u8, entry.name),
-                    .mtime = stat.mtime,
+                    .mtime = stat.mtime.toNanoseconds(),
                     .is_compressed = is_compressed,
                 });
             }
@@ -937,7 +936,7 @@ pub const Rotation = struct {
             // Only attempt to clean if archive_dir is explicitly set to avoid accidents
             if (self.archive_dir) |archive_path| {
                 // Attempt to remove directory. Will fail safely if not empty.
-                std.fs.cwd().deleteDir(archive_path) catch {};
+                std.Io.Dir.cwd().deleteDir(Utils.io(), archive_path) catch {};
             }
         }
     }
@@ -966,7 +965,7 @@ pub const Rotation = struct {
 
                 // Delete original after successful compression if configured
                 if (self.delete_after_retention_compress) {
-                    std.fs.cwd().deleteFile(path) catch {};
+                    std.Io.Dir.cwd().deleteFile(Utils.io(), path) catch {};
                 }
                 return;
             }
@@ -977,7 +976,7 @@ pub const Rotation = struct {
     }
 
     fn deleteFile(self: *Rotation, path: []const u8) !void {
-        std.fs.cwd().deleteFile(path) catch return;
+        std.Io.Dir.cwd().deleteFile(Utils.io(), path) catch return;
         _ = self.stats.files_deleted.fetchAdd(1, .monotonic);
         if (self.on_retention_cleanup) |cb| cb(path);
     }
@@ -1420,15 +1419,15 @@ test "rotation force rotate helper" {
 
     const file_name = try std.fmt.allocPrint(allocator, "rotation_force_{d}.log", .{Utils.currentMillis()});
     defer allocator.free(file_name);
-    defer std.fs.cwd().deleteFile(file_name) catch {};
+    defer std.Io.Dir.cwd().deleteFile(Utils.io(), file_name) catch {};
 
     const rotated_name = try std.fmt.allocPrint(allocator, "{s}.1", .{file_name});
     defer allocator.free(rotated_name);
-    defer std.fs.cwd().deleteFile(rotated_name) catch {};
+    defer std.Io.Dir.cwd().deleteFile(Utils.io(), rotated_name) catch {};
 
-    var file = try std.fs.cwd().createFile(file_name, .{ .read = true, .truncate = true });
-    defer file.close();
-    try file.writeAll("force rotation content");
+    var file = try std.Io.Dir.cwd().createFile(Utils.io(), file_name, .{ .read = true, .truncate = true });
+    defer file.close(Utils.io());
+    try file.writeStreamingAll(Utils.io(), "force rotation content");
 
     var rot = try Rotation.init(allocator, file_name, null, null, 3);
     defer rot.deinit();
@@ -1436,8 +1435,8 @@ test "rotation force rotate helper" {
 
     try rot.forceRotate(&file);
 
-    try std.fs.cwd().access(file_name, .{});
-    try std.fs.cwd().access(rotated_name, .{});
+    try std.Io.Dir.cwd().access(Utils.io(), file_name, .{});
+    try std.Io.Dir.cwd().access(Utils.io(), rotated_name, .{});
     try std.testing.expect(rot.getStats().rotationCount() >= 1);
 }
 
@@ -1478,12 +1477,11 @@ test "rotation reason helpers and preview path" {
 
     const file_name = try std.fmt.allocPrint(allocator, "rotation_reason_{d}.log", .{Utils.currentMillis()});
     defer allocator.free(file_name);
-    defer std.fs.cwd().deleteFile(file_name) catch {};
+    defer std.Io.Dir.cwd().deleteFile(Utils.io(), file_name) catch {};
 
-    var file = try std.fs.cwd().createFile(file_name, .{ .read = true, .truncate = true });
-    defer file.close();
-    try file.writeAll("0123456789");
-    try file.seekTo(0);
+    var file = try std.Io.Dir.cwd().createFile(Utils.io(), file_name, .{ .read = true, .truncate = true });
+    defer file.close(Utils.io());
+    try file.writeStreamingAll(Utils.io(), "0123456789");
 
     var rot = try Rotation.init(allocator, file_name, null, 1, 3);
     defer rot.deinit();

--- a/src/rules.zig
+++ b/src/rules.zig
@@ -37,7 +37,7 @@ pub const Rules = struct {
     allocator: std.mem.Allocator,
     rules: std.ArrayList(Rule),
     enabled: bool = false,
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = std.Io.Mutex.init,
     stats: RulesStats = .{},
     config: RulesConfig = .{},
 
@@ -579,8 +579,8 @@ pub const Rules = struct {
 
     /// Sync configuration from global Config.
     pub fn syncWithGlobalConfig(self: *Rules, global_config: Config) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         const rules_cfg = global_config.rules;
         self.enabled = rules_cfg.enabled;
@@ -635,14 +635,14 @@ pub const Rules = struct {
 
     // Configuration methods
     pub fn enable(self: *Rules) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.enabled = true;
     }
 
     pub fn disable(self: *Rules) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.enabled = false;
     }
 
@@ -651,8 +651,8 @@ pub const Rules = struct {
     }
 
     pub fn configure(self: *Rules, config: RulesConfig) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.config = config;
 
         if (self.config.sort_by_severity) {
@@ -661,21 +661,21 @@ pub const Rules = struct {
     }
 
     pub fn setUnicode(self: *Rules, use_unicode: bool) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.config.use_unicode = use_unicode;
     }
 
     pub fn setColors(self: *Rules, enable_colors: bool) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.config.enable_colors = enable_colors;
     }
 
     /// Update configuration at runtime.
     pub fn setConfig(self: *Rules, new_config: RulesConfig) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.config = new_config;
 
         if (self.config.sort_by_severity) {
@@ -690,38 +690,38 @@ pub const Rules = struct {
 
     // Callback setters
     pub fn setRuleMatchedCallback(self: *Rules, callback: *const fn (*const Rule, *const Record) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_rule_matched = callback;
     }
 
     pub fn setRuleEvaluatedCallback(self: *Rules, callback: *const fn (*const Rule, *const Record, bool) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_rule_evaluated = callback;
     }
 
     pub fn setMessagesAttachedCallback(self: *Rules, callback: *const fn (*const Record, usize) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_messages_attached = callback;
     }
 
     pub fn setEvaluationErrorCallback(self: *Rules, callback: *const fn ([]const u8) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_evaluation_error = callback;
     }
 
     pub fn setBeforeEvaluateCallback(self: *Rules, callback: *const fn (*const Record) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_before_evaluate = callback;
     }
 
     pub fn setAfterEvaluateCallback(self: *Rules, callback: *const fn (*const Record, usize) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_after_evaluate = callback;
     }
 
@@ -736,8 +736,8 @@ pub const Rules = struct {
     ///     error.RuleIdAlreadyExists if a rule with the same ID exists.
     ///     error.TooManyRules if the max rules limit is reached.
     pub fn add(self: *Rules, rule: Rule) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.rules.items.len >= self.config.max_rules) {
             return error.TooManyRules;
@@ -760,8 +760,8 @@ pub const Rules = struct {
     /// Adds a rule, updating it if a rule with the same ID already exists.
     /// Use this when you want to allow updates.
     pub fn addOrUpdate(self: *Rules, rule: Rule) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.rules.items.len >= self.config.max_rules) {
             return error.TooManyRules;
@@ -788,8 +788,8 @@ pub const Rules = struct {
     /// Enables or disables all registered rules.
     /// Returns number of rules updated.
     pub fn setAllEnabled(self: *Rules, enabled: bool) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         var updated: usize = 0;
         for (self.rules.items) |*rule| {
@@ -804,8 +804,8 @@ pub const Rules = struct {
     /// Removes all rules matching a given name.
     /// Returns number of removed rules.
     pub fn removeByName(self: *Rules, name: []const u8) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         var removed: usize = 0;
         var i = self.rules.items.len;
@@ -824,8 +824,8 @@ pub const Rules = struct {
 
     /// Returns count of enabled rules.
     pub fn enabledRuleCount(self: *Rules) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         var enabled_total: usize = 0;
         for (self.rules.items) |rule| {
@@ -836,8 +836,8 @@ pub const Rules = struct {
 
     /// Returns count of disabled rules.
     pub fn disabledRuleCount(self: *Rules) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         var disabled_total: usize = 0;
         for (self.rules.items) |rule| {
@@ -849,8 +849,8 @@ pub const Rules = struct {
     /// Returns true if at least one rule would match this record.
     /// This does not mutate once-only rule state.
     pub fn wouldMatchAny(self: *Rules, record: *const Record) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (!self.enabled or self.rules.items.len == 0) return false;
 
@@ -865,8 +865,8 @@ pub const Rules = struct {
     pub fn matchingRuleIdsWithAllocator(self: *Rules, record: *const Record, scratch_allocator: ?std.mem.Allocator) ?[]u32 {
         const alloc = scratch_allocator orelse self.allocator;
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (!self.enabled or self.rules.items.len == 0) return null;
 
@@ -892,8 +892,8 @@ pub const Rules = struct {
     /// Returns how many rules would match this record.
     /// This does not mutate once-only rule state.
     pub fn matchingRuleCount(self: *Rules, record: *const Record) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (!self.enabled or self.rules.items.len == 0) return 0;
 
@@ -909,8 +909,8 @@ pub const Rules = struct {
     /// Returns the first rule ID that would match this record.
     /// This does not mutate once-only rule state.
     pub fn firstMatchingRuleId(self: *Rules, record: *const Record) ?u32 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (!self.enabled or self.rules.items.len == 0) return null;
 
@@ -924,8 +924,8 @@ pub const Rules = struct {
     ///
     /// Returns true when the rule exists and was updated.
     pub fn setRulePriority(self: *Rules, id: u32, priority: u8) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         for (self.rules.items) |*rule| {
             if (rule.id == id) {
@@ -944,8 +944,8 @@ pub const Rules = struct {
     ///
     /// Returns number of removed rules.
     pub fn removeDisabledRules(self: *Rules) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         var removed: usize = 0;
         var i = self.rules.items.len;
@@ -962,15 +962,15 @@ pub const Rules = struct {
 
     /// Sorts rules by descending priority, then ascending rule ID.
     pub fn sortByPriority(self: *Rules) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.sortRulesByPriorityLocked();
     }
 
     /// Checks if a rule with the given ID exists.
     pub fn hasRule(self: *Rules, id: u32) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         for (self.rules.items) |rule| {
             if (rule.id == id) {
@@ -981,8 +981,8 @@ pub const Rules = struct {
     }
 
     pub fn remove(self: *Rules, id: u32) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         for (self.rules.items, 0..) |rule, i| {
             if (rule.id == id) {
@@ -994,8 +994,8 @@ pub const Rules = struct {
     }
 
     pub fn getById(self: *Rules, id: u32) ?*Rule {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         for (self.rules.items) |*rule| {
             if (rule.id == id) {
@@ -1006,8 +1006,8 @@ pub const Rules = struct {
     }
 
     pub fn enableRule(self: *Rules, id: u32) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         for (self.rules.items) |*rule| {
             if (rule.id == id) {
@@ -1018,8 +1018,8 @@ pub const Rules = struct {
     }
 
     pub fn disableRule(self: *Rules, id: u32) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         for (self.rules.items) |*rule| {
             if (rule.id == id) {
@@ -1030,8 +1030,8 @@ pub const Rules = struct {
     }
 
     pub fn clear(self: *Rules) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.rules.clearRetainingCapacity();
     }
 
@@ -1073,8 +1073,8 @@ pub const Rules = struct {
     }
 
     pub fn resetOnceFired(self: *Rules) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         for (self.rules.items) |*rule| {
             rule.resetFired();
@@ -1097,8 +1097,8 @@ pub const Rules = struct {
             return null;
         }
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.rules.items.len == 0) return null;
 
@@ -1643,13 +1643,13 @@ test "rules format messages" {
         .{ .category = .error_analysis, .message = "Test message" },
     };
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(std.testing.allocator);
+    var buf = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer buf.deinit();
 
-    try rules.formatMessages(&messages, buf.writer(std.testing.allocator), false);
+    try rules.formatMessages(&messages, &buf.writer, false);
 
-    try std.testing.expect(buf.items.len > 0);
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, "Test message") != null);
+    try std.testing.expect(buf.written().len > 0);
+    try std.testing.expect(std.mem.indexOf(u8, buf.written(), "Test message") != null);
 }
 
 test "rules message builders" {
@@ -1701,14 +1701,14 @@ test "rules json format" {
         .{ .category = .solution_suggestion, .message = "Fix it", .url = "https://example.com" },
     };
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(std.testing.allocator);
+    var buf = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer buf.deinit();
 
-    try rules.formatMessagesJson(&messages, buf.writer(std.testing.allocator), false);
+    try rules.formatMessagesJson(&messages, &buf.writer, false);
 
-    try std.testing.expect(buf.items.len > 0);
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, "error_analysis") != null);
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, "solution_suggestion") != null);
+    try std.testing.expect(buf.written().len > 0);
+    try std.testing.expect(std.mem.indexOf(u8, buf.written(), "error_analysis") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.written(), "solution_suggestion") != null);
 }
 
 test "rules duplicate id detection" {
@@ -1979,14 +1979,14 @@ test "rules formatting with config" {
         .{ .category = .solution_suggestion, .message = "Try this fix" },
     };
 
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(std.testing.allocator);
+    var buf = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer buf.deinit();
 
     // Test with colors enabled
-    try rules.formatMessages(&messages, buf.writer(std.testing.allocator), true);
-    try std.testing.expect(buf.items.len > 0);
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, "Error occurred") != null);
-    try std.testing.expect(std.mem.indexOf(u8, buf.items, "Try this fix") != null);
+    try rules.formatMessages(&messages, &buf.writer, true);
+    try std.testing.expect(buf.written().len > 0);
+    try std.testing.expect(std.mem.indexOf(u8, buf.written(), "Error occurred") != null);
+    try std.testing.expect(std.mem.indexOf(u8, buf.written(), "Try this fix") != null);
 }
 
 test "rules stats reset" {

--- a/src/sampler.zig
+++ b/src/sampler.zig
@@ -156,7 +156,7 @@ pub const Sampler = struct {
     /// Internal state (counters, RNG, window tracking).
     state: SamplerState,
     /// Mutex for thread-safe operations.
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = std.Io.Mutex.init,
 
     /// Callback invoked when a record passes sampling.
     /// Parameters: (sample_rate: f64)
@@ -361,13 +361,13 @@ pub const Sampler = struct {
         var rate_exceeded_info: ?RateExceededInfo = null;
         var adjustment_info: ?AdjustmentInfo = null;
 
-        self.mutex.lock();
+        self.mutex.lockUncancelable(Utils.io());
         const sample_decision = self.evaluateSampleDecisionLocked(
             Utils.currentMillis(),
             &rate_exceeded_info,
             &adjustment_info,
         );
-        self.mutex.unlock();
+        self.mutex.unlock(Utils.io());
 
         if (adjustment_info) |info| {
             if (self.on_rate_adjustment) |cb| cb(info.old, info.new, "throughput adjustment");
@@ -403,8 +403,8 @@ pub const Sampler = struct {
 
     /// Updates strategy at runtime and resets strategy-specific counters.
     pub fn setStrategy(self: *Sampler, strategy: Strategy) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         self.strategy = strategy;
         self.resetStateForStrategy();
@@ -447,9 +447,9 @@ pub const Sampler = struct {
             .max_sample_rate = bounded_max,
         } });
 
-        self.mutex.lock();
+        self.mutex.lockUncancelable(Utils.io());
         self.state.current_rate = bounded_max;
-        self.mutex.unlock();
+        self.mutex.unlock(Utils.io());
     }
 
     /// Disables filtering and allows all records through.
@@ -459,8 +459,8 @@ pub const Sampler = struct {
 
     /// Returns remaining quota in current rate-limit window, if applicable.
     pub fn remainingWindowQuota(self: *Sampler) ?u32 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         return switch (self.strategy) {
             .rate_limit => |config| {
@@ -473,8 +473,8 @@ pub const Sampler = struct {
 
     /// Returns milliseconds until rate-limit window reset, if applicable.
     pub fn windowResetInMs(self: *Sampler) ?u64 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         return switch (self.strategy) {
             .rate_limit => |config| {
@@ -498,8 +498,8 @@ pub const Sampler = struct {
 
     /// Resets the sampler state.
     pub fn reset(self: *Sampler) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         self.state = SamplerState.init();
     }
@@ -509,8 +509,8 @@ pub const Sampler = struct {
 
     /// Returns the current sampling rate (for adaptive sampling).
     pub fn getCurrentRate(self: *Sampler) f64 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         return switch (self.strategy) {
             .none => 1.0,
@@ -801,7 +801,7 @@ test "sampler adaptive" {
     }
 
     // Wait for adjustment interval
-    std.Thread.sleep(60 * Constants.TimeConstants.ns_per_ms);
+    Utils.sleepMs(60);
 
     // One more sample to trigger adjustment
     _ = sampler.shouldSample();

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -51,9 +51,9 @@ pub const Scheduler = struct {
     /// Background worker thread for task execution.
     worker_thread: ?std.Thread = null,
     /// Mutex for thread-safe access to tasks.
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = std.Io.Mutex.init,
     /// Condition variable for worker thread signaling.
-    condition: std.Thread.Condition = .{},
+    condition: std.Io.Condition = .init,
     /// Scheduler statistics (tasks executed, failed, etc.).
     stats: SchedulerStats,
     /// Compression utility for compression tasks.
@@ -557,13 +557,13 @@ pub const Scheduler = struct {
         var status = HealthStatus{};
 
         // Check if we can write to current directory
-        const test_file = std.fs.cwd().createFile(".health_check_temp", .{}) catch {
+        const test_file = std.Io.Dir.cwd().createFile(Utils.io(), ".health_check_temp", .{}) catch {
             status.healthy = false;
             status.message = "Cannot write to disk";
             return status;
         };
-        test_file.close();
-        std.fs.cwd().deleteFile(".health_check_temp") catch {};
+        test_file.close(Utils.io());
+        std.Io.Dir.cwd().deleteFile(Utils.io(), ".health_check_temp") catch {};
 
         return status;
     }
@@ -585,8 +585,8 @@ pub const Scheduler = struct {
         schedule: Schedule,
         config: ScheduledTask.TaskConfig,
     ) !usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         const owned_name = try self.allocator.dupe(u8, name);
         errdefer self.allocator.free(owned_name);
@@ -621,8 +621,8 @@ pub const Scheduler = struct {
 
     /// Configures priority for a specific task.
     pub fn setTaskPriority(self: *Scheduler, index: usize, priority: ScheduledTask.Priority) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         if (index < self.tasks.items.len) {
             self.tasks.items[index].priority = priority;
         }
@@ -633,8 +633,8 @@ pub const Scheduler = struct {
 
     /// Configures retry policy for a specific task.
     pub fn setTaskRetryPolicy(self: *Scheduler, index: usize, policy: ScheduledTask.RetryPolicy) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         if (index < self.tasks.items.len) {
             self.tasks.items[index].retry_policy = policy;
             self.tasks.items[index].retries_remaining = policy.max_retries;
@@ -646,8 +646,8 @@ pub const Scheduler = struct {
 
     /// Sets a dependency for a task.
     pub fn setTaskDependency(self: *Scheduler, index: usize, dependency_name: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         if (index < self.tasks.items.len) {
             if (self.tasks.items[index].depends_on) |p| self.allocator.free(p);
             self.tasks.items[index].depends_on = try self.allocator.dupe(u8, dependency_name);
@@ -704,8 +704,8 @@ pub const Scheduler = struct {
         schedule: Schedule,
         callback: *const fn (*ScheduledTask) anyerror!void,
     ) !usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         const owned_name = try self.allocator.dupe(u8, name);
         const now = Utils.currentMillis();
@@ -727,8 +727,8 @@ pub const Scheduler = struct {
 
     /// Enables or disables a task.
     pub fn setTaskEnabled(self: *Scheduler, index: usize, enabled: bool) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         if (index < self.tasks.items.len) {
             self.tasks.items[index].enabled = enabled;
         }
@@ -739,8 +739,8 @@ pub const Scheduler = struct {
 
     /// Removes a task by index.
     pub fn removeTask(self: *Scheduler, index: usize) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         if (index < self.tasks.items.len) {
             const task = self.tasks.orderedRemove(index);
             self.allocator.free(task.name);
@@ -755,8 +755,8 @@ pub const Scheduler = struct {
 
     /// Finds a task index by name.
     pub fn taskIndexByName(self: *Scheduler, name: []const u8) ?usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         for (self.tasks.items, 0..) |task, i| {
             if (std.mem.eql(u8, task.name, name)) return i;
@@ -766,8 +766,8 @@ pub const Scheduler = struct {
 
     /// Returns task snapshot by index.
     pub fn getTaskSnapshot(self: *Scheduler, index: usize) ?TaskSnapshot {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (index >= self.tasks.items.len) return null;
         const task = self.tasks.items[index];
@@ -786,8 +786,8 @@ pub const Scheduler = struct {
 
     /// Returns task snapshot by name.
     pub fn getTaskSnapshotByName(self: *Scheduler, name: []const u8) ?TaskSnapshot {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         for (self.tasks.items) |task| {
             if (std.mem.eql(u8, task.name, name)) {
@@ -816,8 +816,8 @@ pub const Scheduler = struct {
     ///
     /// Returns true when task exists and was updated.
     pub fn setTaskEnabledByName(self: *Scheduler, name: []const u8, enabled: bool) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         for (self.tasks.items) |*task| {
             if (std.mem.eql(u8, task.name, name)) {
@@ -833,8 +833,8 @@ pub const Scheduler = struct {
     ///
     /// Returns true when a task was removed.
     pub fn removeTaskByName(self: *Scheduler, name: []const u8) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         for (self.tasks.items, 0..) |task, i| {
             if (std.mem.eql(u8, task.name, name)) {
@@ -852,8 +852,8 @@ pub const Scheduler = struct {
 
     /// Returns enabled task count.
     pub fn enabledTaskCount(self: *Scheduler) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         var enabled_total: usize = 0;
         for (self.tasks.items) |task| {
@@ -864,8 +864,8 @@ pub const Scheduler = struct {
 
     /// Returns running task count.
     pub fn runningTaskCount(self: *Scheduler) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         var running_total: usize = 0;
         for (self.tasks.items) |task| {
@@ -876,8 +876,8 @@ pub const Scheduler = struct {
 
     /// Returns milliseconds until task next run.
     pub fn nextRunInMs(self: *Scheduler, index: usize) ?i64 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (index >= self.tasks.items.len) return null;
         const delta = self.tasks.items[index].next_run - Utils.currentMillis();
@@ -886,8 +886,8 @@ pub const Scheduler = struct {
 
     /// Returns milliseconds until task next run by task name.
     pub fn nextRunInMsByName(self: *Scheduler, name: []const u8) ?i64 {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         for (self.tasks.items) |task| {
             if (std.mem.eql(u8, task.name, name)) {
@@ -901,8 +901,8 @@ pub const Scheduler = struct {
 
     /// Updates schedule for a task and recalculates next run.
     pub fn setTaskSchedule(self: *Scheduler, index: usize, schedule: Schedule) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (index >= self.tasks.items.len) return false;
 
@@ -913,8 +913,8 @@ pub const Scheduler = struct {
 
     /// Forces a task to become runnable on next scheduler pass.
     pub fn rescheduleNow(self: *Scheduler, index: usize) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (index >= self.tasks.items.len) return false;
 
@@ -925,8 +925,8 @@ pub const Scheduler = struct {
 
     /// Sets the callback for task started events.
     pub fn setTaskStartedCallback(self: *Scheduler, callback: *const fn ([]const u8, u64) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_task_started = callback;
     }
 
@@ -935,8 +935,8 @@ pub const Scheduler = struct {
 
     /// Sets the callback for task completed events.
     pub fn setTaskCompletedCallback(self: *Scheduler, callback: *const fn ([]const u8, u64) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_task_completed = callback;
     }
 
@@ -945,8 +945,8 @@ pub const Scheduler = struct {
 
     /// Sets the callback for task error events.
     pub fn setTaskErrorCallback(self: *Scheduler, callback: *const fn ([]const u8, []const u8) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_task_error = callback;
     }
 
@@ -955,8 +955,8 @@ pub const Scheduler = struct {
 
     /// Sets the callback for schedule tick events.
     pub fn setScheduleTickCallback(self: *Scheduler, callback: *const fn (u32, u32) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_schedule_tick = callback;
     }
 
@@ -965,8 +965,8 @@ pub const Scheduler = struct {
 
     /// Sets the callback for health check events.
     pub fn setHealthCheckCallback(self: *Scheduler, callback: *const fn (*const HealthStatus) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_health_check = callback;
     }
 
@@ -990,7 +990,7 @@ pub const Scheduler = struct {
         if (!self.running.load(.acquire)) return;
 
         self.running.store(false, .release);
-        self.condition.broadcast();
+        self.condition.broadcast(Utils.io());
 
         // Join the worker loop thread
         if (self.worker_thread) |thread| {
@@ -1002,24 +1002,24 @@ pub const Scheduler = struct {
         var wait_loops: u8 = 0;
         while (wait_loops < 50) : (wait_loops += 1) { // 5 second max wait
             var any_running = false;
-            self.mutex.lock();
+            self.mutex.lockUncancelable(Utils.io());
             for (self.tasks.items) |task| {
                 if (task.running) {
                     any_running = true;
                     break;
                 }
             }
-            self.mutex.unlock();
+            self.mutex.unlock(Utils.io());
 
             if (!any_running) break;
-            std.Thread.sleep(100 * Constants.TimeConstants.ns_per_ms);
+            Utils.sleepMs(100);
         }
     }
 
     /// Runs a task immediately regardless of schedule.
     pub fn runNow(self: *Scheduler, index: usize) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (index >= self.tasks.items.len) return;
         try self.executeTask(&self.tasks.items[index]);
@@ -1070,8 +1070,8 @@ pub const Scheduler = struct {
 
     /// Returns number of tasks currently ready to run.
     pub fn readyTaskCount(self: *Scheduler) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         const now = Utils.currentMillis();
         var ready_total: usize = 0;
@@ -1087,7 +1087,7 @@ pub const Scheduler = struct {
         var ready_count: u32 = 0;
         var total_count: u32 = 0;
 
-        self.mutex.lock();
+        self.mutex.lockUncancelable(Utils.io());
         const precheck_now = Utils.currentMillis();
         total_count = @as(u32, @intCast(@min(self.tasks.items.len, std.math.maxInt(u32))));
         for (self.tasks.items) |task| {
@@ -1096,12 +1096,12 @@ pub const Scheduler = struct {
             }
         }
         tick_cb = self.on_schedule_tick;
-        self.mutex.unlock();
+        self.mutex.unlock(Utils.io());
 
         if (tick_cb) |cb| cb(ready_count, total_count);
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         const now = Utils.currentMillis();
         for (self.tasks.items, 0..) |*task, i| {
@@ -1155,8 +1155,8 @@ pub const Scheduler = struct {
     pub const pending = runPending;
 
     fn handleTaskError(self: *Scheduler, index: usize, err: anyerror) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         self.handleTaskErrorLocked(index, err);
     }
@@ -1184,18 +1184,18 @@ pub const Scheduler = struct {
     }
 
     fn runTaskByIndex(self: *Scheduler, index: usize) !void {
-        self.mutex.lock();
+        self.mutex.lockUncancelable(Utils.io());
         if (index >= self.tasks.items.len) {
-            self.mutex.unlock();
+            self.mutex.unlock(Utils.io());
             return;
         }
         const task = &self.tasks.items[index];
-        self.mutex.unlock();
+        self.mutex.unlock(Utils.io());
 
         defer {
-            self.mutex.lock();
+            self.mutex.lockUncancelable(Utils.io());
             task.running = false;
-            self.mutex.unlock();
+            self.mutex.unlock(Utils.io());
         }
 
         try self.executeTask(task);
@@ -1208,7 +1208,7 @@ pub const Scheduler = struct {
             // Check every 500ms for more responsive scheduling
             var i: usize = 0;
             while (i < 5 and self.running.load(.acquire)) : (i += 1) {
-                std.Thread.sleep(100 * Constants.TimeConstants.ns_per_ms);
+                Utils.sleepMs(100);
             }
         }
     }
@@ -1332,10 +1332,10 @@ pub const Scheduler = struct {
         const now = Utils.currentSeconds();
         const max_age = @as(i64, @intCast(config.max_age_seconds));
 
-        var dir = std.fs.cwd().openDir(path, .{ .iterate = true }) catch {
+        var dir = std.Io.Dir.cwd().openDir(Utils.io(), path, .{ .iterate = true }) catch {
             return result;
         };
-        defer dir.close();
+        defer dir.close(Utils.io());
 
         // Collect file info for ranking
         var files: std.ArrayList(FileInfo) = .empty;
@@ -1348,7 +1348,7 @@ pub const Scheduler = struct {
 
         var iter = dir.iterate();
         var total_size: u64 = 0;
-        while (try iter.next()) |entry| {
+        while (try iter.next(Utils.io())) |entry| {
             if (entry.kind != .file) continue;
 
             // Check file pattern
@@ -1357,14 +1357,14 @@ pub const Scheduler = struct {
             }
 
             // Get file stats
-            const file = dir.openFile(entry.name, .{}) catch continue;
-            const stat = file.stat() catch {
-                file.close();
+            const file = dir.openFile(Utils.io(), entry.name, .{}) catch continue;
+            const stat = file.stat(Utils.io()) catch {
+                file.close(Utils.io());
                 continue;
             };
-            file.close();
+            file.close(Utils.io());
 
-            const mtime: i64 = @intCast(@divFloor(stat.mtime, Constants.TimeConstants.ns_per_second));
+            const mtime = stat.mtime.toSeconds();
             const age = now - mtime;
 
             const name_copy = self.allocator.dupe(u8, entry.name) catch continue;
@@ -1426,7 +1426,7 @@ pub const Scheduler = struct {
                 }
 
                 // Default: Delete the file
-                dir.deleteFile(fi.name) catch {
+                dir.deleteFile(Utils.io(), fi.name) catch {
                     result.errors += 1;
                     continue;
                 };
@@ -1446,7 +1446,7 @@ pub const Scheduler = struct {
                     if (deleted_indices.isSet(i)) continue;
                     if (current_count <= max) break;
 
-                    dir.deleteFile(fi.name) catch {
+                    dir.deleteFile(Utils.io(), fi.name) catch {
                         result.errors += 1;
                         continue;
                     };
@@ -1467,7 +1467,7 @@ pub const Scheduler = struct {
                     if (deleted_indices.isSet(i)) continue;
                     if (total_size <= max_size) break;
 
-                    dir.deleteFile(fi.name) catch {
+                    dir.deleteFile(Utils.io(), fi.name) catch {
                         result.errors += 1;
                         continue;
                     };
@@ -1505,12 +1505,12 @@ pub const Scheduler = struct {
 
         if (!self.compression_initialized) return result;
 
-        var dir = std.fs.cwd().openDir(path, .{ .iterate = true }) catch return result;
-        defer dir.close();
+        var dir = std.Io.Dir.cwd().openDir(Utils.io(), path, .{ .iterate = true }) catch return result;
+        defer dir.close(Utils.io());
 
         var iter = dir.iterate();
         const now = Utils.currentSeconds();
-        while (try iter.next()) |entry| {
+        while (try iter.next(Utils.io())) |entry| {
             if (entry.kind != .file) continue;
 
             // Skip already compressed files
@@ -1523,13 +1523,13 @@ pub const Scheduler = struct {
 
             // Check age if min_age_seconds is set
             if (config.min_age_seconds > 0) {
-                const file = dir.openFile(entry.name, .{}) catch continue;
-                const stat = file.stat() catch {
-                    file.close();
+                const file = dir.openFile(Utils.io(), entry.name, .{}) catch continue;
+                const stat = file.stat(Utils.io()) catch {
+                    file.close(Utils.io());
                     continue;
                 };
-                file.close();
-                const mtime: i64 = @intCast(@divFloor(stat.mtime, Constants.TimeConstants.ns_per_second));
+                file.close(Utils.io());
+                const mtime = stat.mtime.toSeconds();
                 if (now - mtime < @as(i64, @intCast(config.min_age_seconds))) continue;
             }
 
@@ -2004,29 +2004,29 @@ test "scheduler maintenance task" {
     defer scheduler.deinit();
 
     const tmp_path = ".test_logs_maintenance";
-    std.fs.cwd().makeDir(tmp_path) catch {};
-    defer std.fs.cwd().deleteTree(tmp_path) catch {};
+    std.Io.Dir.cwd().createDir(Utils.io(), tmp_path, .default_dir) catch {};
+    defer std.Io.Dir.cwd().deleteTree(Utils.io(), tmp_path) catch {};
 
-    var dir = try std.fs.cwd().openDir(tmp_path, .{ .iterate = true });
-    defer dir.close();
+    var dir = try std.Io.Dir.cwd().openDir(Utils.io(), tmp_path, .{ .iterate = true });
+    defer dir.close(Utils.io());
 
     // Create initial set of log files for testing limit enforcement
     var i: usize = 0;
     while (i < 10) : (i += 1) {
         const name = try std.fmt.allocPrint(allocator, "test_{d}.log", .{i});
         defer allocator.free(name);
-        const file = try dir.createFile(name, .{});
-        try file.writeAll("test content");
-        file.close();
+        const file = try dir.createFile(Utils.io(), name, .{});
+        try file.writeStreamingAll(Utils.io(), "test content");
+        file.close(Utils.io());
     }
 
     // Create additional files to test overflow handling
     while (i < 15) : (i += 1) {
         const name = try std.fmt.allocPrint(allocator, "new_{d}.log", .{i});
         defer allocator.free(name);
-        const file = try dir.createFile(name, .{});
-        try file.writeAll("new log content");
-        file.close();
+        const file = try dir.createFile(Utils.io(), name, .{});
+        try file.writeStreamingAll(Utils.io(), "new log content");
+        file.close(Utils.io());
     }
 
     // Verify max_files constraint enforcement
@@ -2041,16 +2041,16 @@ test "scheduler maintenance task" {
 
     var count: usize = 0;
     var iter = dir.iterate();
-    while (try iter.next()) |_| {
+    while (try iter.next(Utils.io())) |_| {
         count += 1;
     }
     try std.testing.expectEqual(@as(usize, 5), count);
 
     // Verify max_total_size constraint enforcement
     {
-        const file = try dir.createFile("large.log", .{});
-        try file.writeAll(&([_]u8{'A'} ** 1024));
-        file.close();
+        const file = try dir.createFile(Utils.io(), "large.log", .{});
+        try file.writeStreamingAll(Utils.io(), &([_]u8{'A'} ** 1024));
+        file.close(Utils.io());
     }
 
     config.max_files = null;

--- a/src/sink.zig
+++ b/src/sink.zig
@@ -36,36 +36,12 @@ const Rotation = @import("rotation.zig").Rotation;
 const Network = @import("network.zig");
 const Utils = @import("utils.zig");
 
-// Helper writer for compression that adapts ArrayList to std.io.Writer interface
-const SinkWriter = struct {
-    writer: std.io.Writer,
-    list: *std.ArrayList(u8),
-    allocator: std.mem.Allocator,
-
-    fn drain(writer: *std.io.Writer, iovecs: []const []const u8, len: usize) error{WriteFailed}!usize {
-        const self: *SinkWriter = @fieldParentPtr("writer", writer);
-        var total: usize = 0;
-        for (iovecs[0..len]) |iov| {
-            self.list.appendSlice(self.allocator, iov) catch return error.WriteFailed;
-            total += iov.len;
-        }
-        return total;
-    }
-
-    const vtable = std.io.Writer.VTable{ .drain = drain };
-
-    pub fn init(list: *std.ArrayList(u8), allocator: std.mem.Allocator, buffer: []u8) SinkWriter {
-        return .{
-            .writer = .{
-                .vtable = &vtable,
-                .buffer = buffer,
-                .end = 0,
-            },
-            .list = list,
-            .allocator = allocator,
-        };
-    }
-};
+fn writeStreamAll(stream: std.Io.net.Stream, data: []const u8) !void {
+    var buffer: [Constants.BufferSizes.message]u8 = undefined;
+    var writer = stream.writer(Utils.io(), &buffer);
+    try writer.interface.writeAll(data);
+    try writer.interface.flush();
+}
 
 /// Abstraction for system-level logging (Event Log on Windows, Syslog on POSIX).
 const SystemLog = struct {
@@ -565,13 +541,13 @@ pub const Sink = struct {
     /// Sink configuration options.
     config: SinkConfig,
     /// File handle for file-based sinks.
-    file: ?std.fs.File = null,
+    file: ?std.Io.File = null,
     /// TCP stream for network sinks.
-    stream: ?std.net.Stream = null,
+    stream: ?std.Io.net.Stream = null,
     /// UDP socket for network sinks.
-    udp_socket: ?std.posix.socket_t = null,
+    udp_socket: ?std.Io.net.Socket = null,
     /// UDP destination address.
-    udp_addr: ?std.net.Address = null,
+    udp_addr: ?std.Io.net.IpAddress = null,
     /// System log handle (Windows Event Log / Syslog).
     system_log: ?SystemLog = null,
     /// Formatter for converting records to output.
@@ -581,7 +557,7 @@ pub const Sink = struct {
     /// Internal write buffer.
     buffer: std.ArrayList(u8),
     /// Mutex for thread-safe operations.
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = std.Io.Mutex.init,
     /// Whether the sink is enabled.
     enabled: bool = true,
     /// Track if this is the first JSON entry for file output.
@@ -653,13 +629,13 @@ pub const Sink = struct {
 
                 const dir = std.fs.path.dirname(path);
                 if (dir) |d| {
-                    std.fs.cwd().makePath(d) catch {
+                    std.Io.Dir.cwd().createDirPath(Utils.io(), d) catch {
                         // Failed to create directory - continue anyway
                     };
                 }
 
                 // Use overwrite_mode to determine file truncation behavior
-                sink.file = try std.fs.cwd().createFile(path, .{
+                sink.file = try std.Io.Dir.cwd().createFile(Utils.io(), path, .{
                     .read = true,
                     .truncate = config.overwrite_mode,
                 });
@@ -667,7 +643,7 @@ pub const Sink = struct {
                 // Write opening bracket for JSON array files
                 if (config.json) {
                     if (sink.file) |file| {
-                        try file.writeAll("[\n");
+                        try file.writeStreamingAll(Utils.io(), "[\n");
                     }
                 }
 
@@ -702,9 +678,9 @@ pub const Sink = struct {
     pub const create = init;
 
     fn resolvePath(allocator: std.mem.Allocator, path_pattern: []const u8) ![]u8 {
-        var buf: std.ArrayList(u8) = .empty;
-        errdefer buf.deinit(allocator);
-        const writer = buf.writer(allocator);
+        var buf = std.Io.Writer.Allocating.init(allocator);
+        errdefer buf.deinit();
+        const writer = &buf.writer;
 
         const now_ms = Utils.currentMillis();
         const tc = Utils.fromMilliTimestamp(now_ms);
@@ -741,7 +717,7 @@ pub const Sink = struct {
                 i += 1;
             }
         }
-        return buf.toOwnedSlice(allocator);
+        return buf.toOwnedSlice();
     }
 
     /// Deinitializes the sink and releases resources.
@@ -756,12 +732,12 @@ pub const Sink = struct {
         // Write closing bracket for JSON array files
         if (self.config.json and self.file != null) {
             if (self.file) |file| {
-                file.writeAll("\n]") catch {};
+                file.writeStreamingAll(Utils.io(), "\n]") catch {};
             }
         }
-        if (self.file) |f| f.close();
-        if (self.stream) |s| s.close();
-        if (self.udp_socket) |s| std.posix.close(s);
+        if (self.file) |f| f.close(Utils.io());
+        if (self.stream) |s| s.close(Utils.io());
+        if (self.udp_socket) |s| s.close(Utils.io());
 
         if (self.rotation) |*r| r.deinit();
         self.buffer.deinit(self.allocator);
@@ -774,8 +750,8 @@ pub const Sink = struct {
 
     /// Sets the callback for write events.
     pub fn setWriteCallback(self: *Sink, callback: *const fn (u64, u64) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_write = callback;
     }
 
@@ -784,8 +760,8 @@ pub const Sink = struct {
 
     /// Sets the callback for flush events.
     pub fn setFlushCallback(self: *Sink, callback: *const fn (u64, u64) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_flush = callback;
     }
 
@@ -794,8 +770,8 @@ pub const Sink = struct {
 
     /// Sets the callback for error events.
     pub fn setErrorCallback(self: *Sink, callback: *const fn ([]const u8, u64) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_error = callback;
     }
 
@@ -804,8 +780,8 @@ pub const Sink = struct {
 
     /// Sets the callback for rotation events.
     pub fn setRotationCallback(self: *Sink, callback: *const fn ([]const u8, []const u8) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_rotation = callback;
     }
 
@@ -814,8 +790,8 @@ pub const Sink = struct {
 
     /// Sets the callback for state changes.
     pub fn setStateChangeCallback(self: *Sink, callback: *const fn (bool) void) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.on_state_change = callback;
     }
 
@@ -824,8 +800,8 @@ pub const Sink = struct {
 
     /// Returns sink statistics.
     pub fn getStats(self: *Sink) SinkStats {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         return self.stats;
     }
@@ -836,8 +812,8 @@ pub const Sink = struct {
 
     /// Clears the internal buffer.
     pub fn clearBuffer(self: *Sink) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.buffer.clearRetainingCapacity();
     }
 
@@ -852,8 +828,8 @@ pub const Sink = struct {
 
     /// Returns true if sink is enabled.
     pub fn isEnabled(self: *Sink) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         return self.enabled;
     }
 
@@ -862,24 +838,24 @@ pub const Sink = struct {
 
     /// Enables the sink.
     pub fn enable(self: *Sink) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.enabled = true;
         if (self.on_state_change) |cb| cb(true);
     }
 
     /// Disables the sink.
     pub fn disable(self: *Sink) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.enabled = false;
         if (self.on_state_change) |cb| cb(false);
     }
 
     /// Returns true if async writing is enabled for this sink.
     pub fn isAsyncEnabled(self: *Sink) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         return self.config.async_write;
     }
 
@@ -888,15 +864,15 @@ pub const Sink = struct {
 
     /// Enables async writing for this sink.
     pub fn enableAsync(self: *Sink) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.config.async_write = true;
     }
 
     /// Disables async writing for this sink (forces immediate flush).
     pub fn disableAsync(self: *Sink) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.config.async_write = false;
         // Flush any pending data when disabling async
         self.flush() catch {};
@@ -905,8 +881,8 @@ pub const Sink = struct {
     /// Manually flushes the sink buffer.
     /// Thread-safe: Uses mutex for concurrent access protection.
     pub fn flushNow(self: *Sink) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         try self.flush();
     }
 
@@ -937,8 +913,8 @@ pub const Sink = struct {
     ///     global_config: Global configuration.
     ///     scratch_allocator: Optional allocator for temporary formatting.
     pub fn writeWithAllocator(self: *Sink, record: *const Record, global_config: anytype, scratch_allocator: ?std.mem.Allocator) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (!self.enabled) return;
 
@@ -1011,7 +987,9 @@ pub const Sink = struct {
         if (self.system_log) |*syslog| {
             // Clear buffer to ensure we only send the current message
             self.buffer.clearRetainingCapacity();
-            const writer = self.buffer.writer(self.allocator);
+            var buffer_writer = std.Io.Writer.Allocating.fromArrayList(self.allocator, &self.buffer);
+            errdefer self.buffer = buffer_writer.toArrayList();
+            const writer = &buffer_writer.writer;
 
             // Format message
             if (effective_config.json) {
@@ -1019,26 +997,30 @@ pub const Sink = struct {
             } else {
                 try formatter.formatToWriter(writer, record, effective_config);
             }
+            const written = buffer_writer.written();
 
             // Send to system log
-            if (self.buffer.items.len > 0) {
-                try syslog.log(record.level, self.buffer.items);
+            if (written.len > 0) {
+                try syslog.log(record.level, written);
 
                 // Update stats
                 _ = self.stats.total_written.fetchAdd(1, .monotonic);
-                _ = self.stats.bytes_written.fetchAdd(self.buffer.items.len, .monotonic);
+                _ = self.stats.bytes_written.fetchAdd(written.len, .monotonic);
 
                 if (self.on_write) |cb| {
-                    cb(1, self.buffer.items.len);
+                    cb(1, written.len);
                 }
             }
 
+            self.buffer = buffer_writer.toArrayList();
             self.buffer.clearRetainingCapacity();
             return;
         }
 
         // Write to buffer
-        const writer = self.buffer.writer(self.allocator);
+        var buffer_writer = std.Io.Writer.Allocating.fromArrayList(self.allocator, &self.buffer);
+        errdefer self.buffer = buffer_writer.toArrayList();
+        const writer = &buffer_writer.writer;
         const is_file = self.file != null;
         const use_json_array = is_file and effective_config.json;
 
@@ -1056,6 +1038,7 @@ pub const Sink = struct {
             }
             try writer.writeByte('\n');
         }
+        self.buffer = buffer_writer.toArrayList();
 
         self.buffered_records += 1;
 
@@ -1077,8 +1060,8 @@ pub const Sink = struct {
     /// Arguments:
     ///     data: The raw string data to write.
     pub fn writeRaw(self: *Sink, data: []const u8) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (!self.enabled) return;
 
@@ -1093,11 +1076,11 @@ pub const Sink = struct {
                     try self.flush();
                 }
             } else {
-                file.writeAll(data) catch |err| {
+                file.writeStreamingAll(Utils.io(), data) catch |err| {
                     try self.handleWriteError(err, 1);
                     return;
                 };
-                file.writeAll("\n") catch |err| {
+                file.writeStreamingAll(Utils.io(), "\n") catch |err| {
                     try self.handleWriteError(err, 1);
                     return;
                 };
@@ -1109,11 +1092,11 @@ pub const Sink = struct {
                 }
             }
         } else if (self.stream) |stream| {
-            stream.writeAll(data) catch |err| {
+            writeStreamAll(stream, data) catch |err| {
                 try self.handleWriteError(err, 1);
                 return;
             };
-            stream.writeAll("\n") catch |err| {
+            writeStreamAll(stream, "\n") catch |err| {
                 try self.handleWriteError(err, 1);
                 return;
             };
@@ -1137,12 +1120,12 @@ pub const Sink = struct {
                 cb(1, data.len);
             }
         } else {
-            const stdout_file = std.fs.File.stdout();
-            stdout_file.writeAll(data) catch |err| {
+            const stdout_file = std.Io.File.stdout();
+            stdout_file.writeStreamingAll(Utils.io(), data) catch |err| {
                 try self.handleWriteError(err, 1);
                 return;
             };
-            stdout_file.writeAll("\n") catch |err| {
+            stdout_file.writeStreamingAll(Utils.io(), "\n") catch |err| {
                 try self.handleWriteError(err, 1);
                 return;
             };
@@ -1156,19 +1139,19 @@ pub const Sink = struct {
     }
 
     fn reconnect(self: *Sink) bool {
-        if (self.stream) |s| s.close();
+        if (self.stream) |s| s.close(Utils.io());
         self.stream = null;
 
         if (self.config.path) |uri| {
             if (std.mem.startsWith(u8, uri, "tcp://")) {
                 const max_retries = Constants.TimeDefaults.max_retries;
-                const retry_sleep_ns = Constants.TimeDefaults.retry_delay_ms * std.time.ns_per_ms;
+                const retry_sleep = std.Io.Duration.fromMilliseconds(Constants.TimeDefaults.retry_delay_ms);
 
                 var attempt: u32 = 0;
                 while (attempt <= max_retries) : (attempt += 1) {
                     self.stream = Network.connectTcp(self.allocator, uri) catch {
                         if (attempt < max_retries) {
-                            std.Thread.sleep(retry_sleep_ns);
+                            Utils.io().sleep(retry_sleep, .awake) catch {};
                         }
                         continue;
                     };
@@ -1206,7 +1189,7 @@ pub const Sink = struct {
     pub fn flush(self: *Sink) !void {
         if (self.buffer.items.len == 0) return;
 
-        const start_ns = std.time.nanoTimestamp();
+        const start_ns = Utils.currentNanos();
         const buffered_records = if (self.buffered_records == 0) @as(u64, 1) else @as(u64, @intCast(self.buffered_records));
 
         // Compression for Network Sinks
@@ -1214,35 +1197,33 @@ pub const Sink = struct {
         var compressed_data: ?[]u8 = null;
 
         if (self.config.compression.enabled and (self.stream != null or self.udp_socket != null)) {
-            var list = try std.ArrayList(u8).initCapacity(self.allocator, Constants.BufferSizes.message);
-            errdefer list.deinit(self.allocator);
+            var list = try std.Io.Writer.Allocating.initCapacity(self.allocator, Constants.BufferSizes.message);
+            errdefer list.deinit();
 
             var compress_buffer: [Constants.BufferSizes.message]u8 = undefined;
-            var sink_writer_buffer: [Constants.BufferSizes.message]u8 = undefined;
-            var sink_writer = SinkWriter.init(&list, self.allocator, &sink_writer_buffer);
 
-            var compressor = std.compress.flate.Compress.init(&sink_writer.writer, &compress_buffer, .{});
+            var compressor = try std.compress.flate.Compress.init(&list.writer, &compress_buffer, .raw, .default);
 
             try compressor.writer.writeAll(self.buffer.items);
-            try compressor.end();
+            try compressor.finish();
 
-            compressed_data = try list.toOwnedSlice(self.allocator);
+            compressed_data = try list.toOwnedSlice();
             data_to_write = compressed_data.?;
         }
         defer if (compressed_data) |d| self.allocator.free(d);
 
         if (self.file) |file| {
-            file.writeAll(self.buffer.items) catch |err| {
+            file.writeStreamingAll(Utils.io(), self.buffer.items) catch |err| {
                 try self.handleWriteError(err, buffered_records);
                 self.buffer.clearRetainingCapacity();
                 self.buffered_records = 0;
                 return;
             };
         } else if (self.stream) |stream| {
-            stream.writeAll(data_to_write) catch |err| {
+            writeStreamAll(stream, data_to_write) catch |err| {
                 if (self.reconnect()) {
                     if (self.stream) |new_stream| {
-                        new_stream.writeAll(data_to_write) catch |retry_err| {
+                        writeStreamAll(new_stream, data_to_write) catch |retry_err| {
                             try self.handleWriteError(retry_err, buffered_records);
                             self.buffer.clearRetainingCapacity();
                             self.buffered_records = 0;
@@ -1263,7 +1244,7 @@ pub const Sink = struct {
             };
         } else if (self.udp_socket) |sock| {
             if (self.udp_addr) |addr| {
-                _ = std.posix.sendto(sock, data_to_write, 0, &addr.any, addr.getOsSockLen()) catch |err| {
+                sock.send(Utils.io(), &addr, data_to_write) catch |err| {
                     try self.handleWriteError(err, buffered_records);
                     self.buffer.clearRetainingCapacity();
                     self.buffered_records = 0;
@@ -1283,8 +1264,8 @@ pub const Sink = struct {
             }
         } else {
             // Console
-            const stdout_file = std.fs.File.stdout();
-            stdout_file.writeAll(self.buffer.items) catch |err| {
+            const stdout_file = std.Io.File.stdout();
+            stdout_file.writeStreamingAll(Utils.io(), self.buffer.items) catch |err| {
                 try self.handleWriteError(err, buffered_records);
                 self.buffer.clearRetainingCapacity();
                 self.buffered_records = 0;
@@ -1293,7 +1274,7 @@ pub const Sink = struct {
         }
 
         const bytes_flushed = if (self.file != null) self.buffer.items.len else data_to_write.len;
-        const end_ns = std.time.nanoTimestamp();
+        const end_ns = Utils.currentNanos();
         const duration_ns: u64 = if (end_ns > start_ns) @as(u64, @intCast(end_ns - start_ns)) else 0;
         const buffered_records_atomic: Constants.AtomicUnsigned = @intCast(@min(
             buffered_records,
@@ -1420,7 +1401,7 @@ test "sink flush updates stats" {
     sink_cfg.overwrite_mode = true;
 
     const sink = try Sink.init(allocator, sink_cfg);
-    defer std.fs.cwd().deleteFile(log_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(Utils.io(), log_path) catch {};
     defer sink.deinit();
 
     var record = Record.init(allocator, .info, "stats check");
@@ -1450,7 +1431,7 @@ test "sink manual flushNow updates stats" {
     sink_cfg.overwrite_mode = true;
 
     const sink = try Sink.init(allocator, sink_cfg);
-    defer std.fs.cwd().deleteFile(log_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(Utils.io(), log_path) catch {};
     defer sink.deinit();
 
     var record = Record.init(allocator, .info, "manual flush stats check");

--- a/src/telemetry.zig
+++ b/src/telemetry.zig
@@ -57,6 +57,7 @@
 
 const std = @import("std");
 const utils = @import("utils.zig");
+const Utils = utils;
 const config_module = @import("config.zig");
 const Network = @import("network.zig");
 const Constants = @import("constants.zig");
@@ -287,7 +288,7 @@ pub const Telemetry = struct {
     sampler: TelemetrySampler,
 
     // Thread safety
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = std.Io.Mutex.init,
 
     // Statistics
     total_spans_created: u64 = 0,
@@ -304,8 +305,8 @@ pub const Telemetry = struct {
     on_error: ?*const fn ([]const u8) void,
 
     // Network connection for network export mode
-    network_socket: ?std.posix.socket_t = null,
-    network_address: ?std.net.Address = null,
+    network_socket: ?std.Io.net.Socket = null,
+    network_address: ?std.Io.net.IpAddress = null,
 
     // Batch buffer for batch export mode
     batch_buffer: std.ArrayList(u8),
@@ -365,12 +366,12 @@ pub const Telemetry = struct {
     pub fn deinit(self: *Telemetry) void {
         // Close network socket if open
         if (self.network_socket) |socket| {
-            std.posix.close(socket);
+            socket.close(Utils.io());
             self.network_socket = null;
         }
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
 
         // Free all active spans
         for (self.spans.items) |*span| {
@@ -403,8 +404,8 @@ pub const Telemetry = struct {
     pub fn startSpan(self: *Telemetry, name: []const u8, opts: SpanOptions) !Span {
         if (!self.enabled) return Span.empty(self.allocator);
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
 
         // Generate IDs using utils
         const span_id = try utils.generateSpanId(self.allocator);
@@ -447,8 +448,8 @@ pub const Telemetry = struct {
     pub fn endSpan(self: *Telemetry, span: *Span) !void {
         if (!self.enabled or span.isEmpty()) return;
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
 
         span.end_time = utils.currentNanos();
 
@@ -512,8 +513,8 @@ pub const Telemetry = struct {
     pub fn recordMetric(self: *Telemetry, name: []const u8, value: f64, opts: MetricOptions) !void {
         if (!self.enabled) return;
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
 
         // Store metric in ArrayList
         try self.metrics.append(self.allocator, .{
@@ -602,7 +603,8 @@ pub const Telemetry = struct {
     /// Compatible with OpenTelemetry Collector and OTLP-compatible backends
     fn exportToOtlp(self: *Telemetry) !void {
         self.batch_buffer.clearRetainingCapacity();
-        const writer = self.batch_buffer.writer(self.allocator);
+        var batch_writer = Utils.ArrayListWriter.init(&self.batch_buffer, self.allocator);
+        const writer = &batch_writer.writer;
 
         try self.writeOtlpSpans(writer);
 
@@ -611,11 +613,14 @@ pub const Telemetry = struct {
             try Network.sendUdp(self.network_socket.?, self.network_address.?, self.batch_buffer.items);
             self.exporter_stats.recordNetworkExport();
         } else if (self.config.exporter_file_path) |path| {
-            const file = try std.fs.cwd().createFile(path, .{ .truncate = false });
-            defer file.close();
-            try file.seekFromEnd(0);
-            try file.writeAll(self.batch_buffer.items);
-            try file.writeAll("\n");
+            const file = try std.Io.Dir.cwd().createFile(Utils.io(), path, .{ .truncate = false });
+            defer file.close(Utils.io());
+            var file_buffer: [Constants.BufferSizes.telemetry]u8 = undefined;
+            var file_writer = file.writer(Utils.io(), &file_buffer);
+            try file_writer.seekTo(try file.length(Utils.io()));
+            try file_writer.interface.writeAll(self.batch_buffer.items);
+            try file_writer.interface.writeAll("\n");
+            try file_writer.interface.flush();
         }
 
         self.exporter_stats.recordExport(self.completed_spans.items.len, self.batch_buffer.items.len);
@@ -722,11 +727,11 @@ pub const Telemetry = struct {
             },
             .integer => |i| {
                 try writer.writeAll("\"intValue\":");
-                try std.fmt.format(writer, "{d}", .{i});
+                try writer.print( "{d}", .{i});
             },
             .float => |f| {
                 try writer.writeAll("\"doubleValue\":");
-                try std.fmt.format(writer, "{d:.6}", .{f});
+                try writer.print( "{d:.6}", .{f});
             },
             .boolean => |b| {
                 try writer.writeAll("\"boolValue\":");
@@ -749,7 +754,8 @@ pub const Telemetry = struct {
     /// Export to Jaeger (Thrift JSON format)
     fn exportToJaeger(self: *Telemetry) !void {
         self.batch_buffer.clearRetainingCapacity();
-        const writer = self.batch_buffer.writer(self.allocator);
+        var batch_writer = Utils.ArrayListWriter.init(&self.batch_buffer, self.allocator);
+        const writer = &batch_writer.writer;
 
         try writer.writeAll("{\"data\":[{\"traceID\":\"");
         if (self.completed_spans.items.len > 0) {
@@ -792,7 +798,8 @@ pub const Telemetry = struct {
     /// Export to Zipkin format
     fn exportToZipkin(self: *Telemetry) !void {
         self.batch_buffer.clearRetainingCapacity();
-        const writer = self.batch_buffer.writer(self.allocator);
+        var batch_writer = Utils.ArrayListWriter.init(&self.batch_buffer, self.allocator);
+        const writer = &batch_writer.writer;
 
         try writer.writeByte('[');
         for (self.completed_spans.items, 0..) |span, i| {
@@ -828,7 +835,8 @@ pub const Telemetry = struct {
     /// Export to Datadog APM format
     fn exportToDatadog(self: *Telemetry) !void {
         self.batch_buffer.clearRetainingCapacity();
-        const writer = self.batch_buffer.writer(self.allocator);
+        var batch_writer = Utils.ArrayListWriter.init(&self.batch_buffer, self.allocator);
+        const writer = &batch_writer.writer;
 
         try writer.writeAll("[[");
         for (self.completed_spans.items, 0..) |span, i| {
@@ -870,7 +878,8 @@ pub const Telemetry = struct {
     /// Export to Google Analytics 4 Measurement Protocol
     fn exportToGoogleAnalytics(self: *Telemetry) !void {
         self.batch_buffer.clearRetainingCapacity();
-        const writer = self.batch_buffer.writer(self.allocator);
+        var batch_writer = Utils.ArrayListWriter.init(&self.batch_buffer, self.allocator);
+        const writer = &batch_writer.writer;
 
         try writer.writeAll("{\"client_id\":\"logly_");
         if (self.completed_spans.items.len > 0) {
@@ -909,7 +918,8 @@ pub const Telemetry = struct {
     /// Export to AWS X-Ray format
     fn exportToAwsXray(self: *Telemetry) !void {
         self.batch_buffer.clearRetainingCapacity();
-        const writer = self.batch_buffer.writer(self.allocator);
+        var batch_writer = Utils.ArrayListWriter.init(&self.batch_buffer, self.allocator);
+        const writer = &batch_writer.writer;
 
         for (self.completed_spans.items, 0..) |span, i| {
             if (i > 0) try writer.writeByte('\n');
@@ -933,12 +943,12 @@ pub const Telemetry = struct {
         try writer.writeAll("\",\"start_time\":");
         const ns_per_sec_f = @as(f64, @floatFromInt(Constants.TimeConstants.ns_per_second));
         const start_s = @as(f64, @floatFromInt(utils.safeToUnsigned(u64, span.start_time))) / ns_per_sec_f;
-        try std.fmt.format(writer, "{d:.6}", .{start_s});
+        try writer.print( "{d:.6}", .{start_s});
         if (span.end_time > 0) {
             try writer.writeAll(",\"end_time\":");
             const ns_per_sec_end_f = @as(f64, @floatFromInt(Constants.TimeConstants.ns_per_second));
             const end_s = @as(f64, @floatFromInt(utils.safeToUnsigned(u64, span.end_time))) / ns_per_sec_end_f;
-            try std.fmt.format(writer, "{d:.6}", .{end_s});
+            try writer.print( "{d:.6}", .{end_s});
         }
         try writer.writeAll(",\"origin\":\"");
         try writer.writeAll(self.resource.service_name orelse "unknown");
@@ -948,7 +958,8 @@ pub const Telemetry = struct {
     /// Export to Azure Application Insights format
     fn exportToAzure(self: *Telemetry) !void {
         self.batch_buffer.clearRetainingCapacity();
-        const writer = self.batch_buffer.writer(self.allocator);
+        var batch_writer = Utils.ArrayListWriter.init(&self.batch_buffer, self.allocator);
+        const writer = &batch_writer.writer;
 
         try writer.writeByte('[');
         for (self.completed_spans.items, 0..) |span, i| {
@@ -967,7 +978,7 @@ pub const Telemetry = struct {
         // Write ISO 8601 timestamp
         const timestamp_ns = utils.safeToUnsigned(u64, span.start_time);
         const timestamp_s = timestamp_ns / Constants.TimeConstants.ns_per_second;
-        try std.fmt.format(writer, "{d}", .{timestamp_s});
+        try writer.print( "{d}", .{timestamp_s});
         try writer.writeAll("\",\"data\":{\"baseType\":\"RequestData\",\"baseData\":{");
         try writer.writeAll("\"id\":\"");
         try writer.writeAll(span.span_id);
@@ -982,7 +993,7 @@ pub const Telemetry = struct {
             const minutes = (duration_ms % 3_600_000) / 60_000;
             const seconds = (duration_ms % 60_000) / 1_000;
             const ms = duration_ms % 1_000;
-            try std.fmt.format(writer, "{d:0>2}:{d:0>2}:{d:0>2}.{d:0>3}", .{ hours, minutes, seconds, ms });
+            try writer.print( "{d:0>2}:{d:0>2}:{d:0>2}.{d:0>3}", .{ hours, minutes, seconds, ms });
             try writer.writeByte('"');
         }
         try writer.writeAll("}},\"iKey\":\"");
@@ -1003,20 +1014,22 @@ pub const Telemetry = struct {
     fn exportToFile(self: *Telemetry) !void {
         const path = self.config.exporter_file_path orelse return;
 
-        const file = try std.fs.cwd().createFile(path, .{ .truncate = false });
-        defer file.close();
-
-        // Seek to end for append
-        try file.seekFromEnd(0);
+        const file = try std.Io.Dir.cwd().createFile(Utils.io(), path, .{ .truncate = false });
+        defer file.close(Utils.io());
 
         // Write each span as a JSON line
+        var file_buffer: [Constants.BufferSizes.telemetry]u8 = undefined;
+        var file_writer = file.writer(Utils.io(), &file_buffer);
+        try file_writer.seekTo(try file.length(Utils.io()));
         for (self.completed_spans.items) |span| {
             self.batch_buffer.clearRetainingCapacity();
-            const writer = self.batch_buffer.writer(self.allocator);
+            var batch_writer = Utils.ArrayListWriter.init(&self.batch_buffer, self.allocator);
+            const writer = &batch_writer.writer;
             try self.writeSpanJson(writer, span);
             try writer.writeByte('\n');
-            try file.writeAll(self.batch_buffer.items);
+            try file_writer.interface.writeAll(self.batch_buffer.items);
         }
+        try file_writer.interface.flush();
     }
 
     /// Export spans to network (TCP/UDP) using Network module
@@ -1025,7 +1038,8 @@ pub const Telemetry = struct {
 
         // Build JSON batch
         self.batch_buffer.clearRetainingCapacity();
-        const writer = self.batch_buffer.writer(self.allocator);
+        var batch_writer = Utils.ArrayListWriter.init(&self.batch_buffer, self.allocator);
+        const writer = &batch_writer.writer;
 
         try writer.writeAll("{\"spans\":[");
         for (self.completed_spans.items, 0..) |span, i| {
@@ -1084,7 +1098,7 @@ pub const Telemetry = struct {
                         try writer.writeByte('"');
                     },
                     .integer => |i| try utils.writeInt(writer, i),
-                    .float => |f| try std.fmt.format(writer, "{d:.6}", .{f}),
+                    .float => |f| try writer.print( "{d:.6}", .{f}),
                     .boolean => |b| try writer.writeAll(if (b) "true" else "false"),
                     .string_array => |arr| {
                         try writer.writeByte('[');
@@ -1109,8 +1123,8 @@ pub const Telemetry = struct {
     pub fn exportSpans(self: *Telemetry) !void {
         if (!self.enabled) return;
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
 
         try self.exportSpansInternal();
     }
@@ -1119,8 +1133,8 @@ pub const Telemetry = struct {
     pub fn exportMetrics(self: *Telemetry) !void {
         if (!self.enabled) return;
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
 
         // Clear metrics after export
         for (self.metrics.items) |metric| {
@@ -1138,29 +1152,29 @@ pub const Telemetry = struct {
 
     /// Returns the number of active spans
     pub fn getActiveSpanCount(self: *Telemetry) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
         return self.active_span_count;
     }
 
     /// Returns the number of completed spans awaiting export
     pub fn getCompletedSpanCount(self: *Telemetry) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
         return self.completed_span_count;
     }
 
     /// Returns the current metric count
     pub fn getMetricCount(self: *Telemetry) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
         return self.metric_count;
     }
 
     /// Returns telemetry statistics
     pub fn getStats(self: *Telemetry) TelemetryStats {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
         return .{
             .total_spans_created = self.total_spans_created,
             .total_spans_exported = self.total_spans_exported,
@@ -1193,8 +1207,8 @@ pub const Telemetry = struct {
 
     /// Enable/disable telemetry at runtime
     pub fn setEnabled(self: *Telemetry, enabled: bool) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
         self.enabled = enabled;
     }
 
@@ -1205,8 +1219,8 @@ pub const Telemetry = struct {
 
     /// Updates telemetry sampling strategy and effective sampling rate.
     pub fn setSampling(self: *Telemetry, strategy: TelemetryConfig.SamplingStrategy, sampling_rate: f64) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
 
         const clamped_rate = clampSamplingRate(sampling_rate);
 
@@ -1220,8 +1234,8 @@ pub const Telemetry = struct {
 
     /// Returns current telemetry sampling configuration.
     pub fn getSampling(self: *Telemetry) SamplingSnapshot {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
 
         return .{
             .strategy = self.config.sampling_strategy,
@@ -1231,8 +1245,8 @@ pub const Telemetry = struct {
 
     /// Sets context propagation header names at runtime.
     pub fn setContextHeaders(self: *Telemetry, trace_header: []const u8, baggage_header: []const u8) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
 
         self.config.trace_header = trace_header;
         self.config.baggage_header = baggage_header;
@@ -1240,8 +1254,8 @@ pub const Telemetry = struct {
 
     /// Returns currently configured context propagation headers.
     pub fn getContextHeaders(self: *Telemetry) ContextHeaders {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
 
         return .{
             .trace_header = self.config.trace_header,
@@ -1251,16 +1265,16 @@ pub const Telemetry = struct {
 
     /// Returns true when spans or metrics are waiting to be exported.
     pub fn hasPendingData(self: *Telemetry) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
 
         return self.completed_span_count > 0 or self.metric_count > 0;
     }
 
     /// Returns total number of pending spans + metrics.
     pub fn pendingItemCount(self: *Telemetry) usize {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
 
         return self.completed_span_count + self.metric_count;
     }
@@ -1277,15 +1291,15 @@ pub const Telemetry = struct {
 
     /// Update resource configuration at runtime
     pub fn setResource(self: *Telemetry, resource: Resource) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
         self.resource = resource;
     }
 
     /// Reset all statistics counters
     pub fn resetStats(self: *Telemetry) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
         self.total_spans_created = 0;
         self.total_spans_exported = 0;
         self.total_metrics_recorded = 0;
@@ -1294,8 +1308,8 @@ pub const Telemetry = struct {
 
     /// Get span by trace_id (for distributed trace continuation)
     pub fn findSpanByTraceId(self: *Telemetry, trace_id: []const u8) ?*const Span {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(utils.io());
+        defer self.mutex.unlock(utils.io());
 
         for (self.spans.items) |*span| {
             if (std.mem.eql(u8, span.trace_id, trace_id)) {
@@ -1706,8 +1720,9 @@ pub const Baggage = struct {
 
     /// Format as W3C baggage header value
     pub fn toHeaderValue(self: *Baggage, allocator: std.mem.Allocator) ![]const u8 {
-        var result = std.ArrayList(u8).initCapacity(allocator, Constants.TelemetryDefaults.header_initial_capacity) catch return "";
-        const writer = result.writer(allocator);
+        var result = std.Io.Writer.Allocating.initCapacity(allocator, Constants.TelemetryDefaults.header_initial_capacity) catch return "";
+        errdefer result.deinit();
+        const writer = &result.writer;
 
         var it = self.items.iterator();
         var first = true;
@@ -1719,7 +1734,7 @@ pub const Baggage = struct {
             first = false;
         }
 
-        return result.toOwnedSlice(allocator);
+        return result.toOwnedSlice();
     }
 
     /// Parse W3C baggage header value
@@ -2136,7 +2151,7 @@ test "Span duration helpers" {
     defer span.deinit();
 
     // Small delay
-    std.Thread.sleep(1_000_000); // 1ms
+    Utils.io().sleep(.fromMilliseconds(1), .awake) catch {}; // 1ms
 
     span.end();
 

--- a/src/thread_pool.zig
+++ b/src/thread_pool.zig
@@ -288,8 +288,8 @@ pub const ThreadPool = struct {
         tail: usize = 0,
         count: usize = 0,
         capacity: usize,
-        mutex: std.Thread.Mutex = .{},
-        condition: std.Thread.Condition = .{},
+        mutex: std.Io.Mutex = .init,
+        condition: std.Io.Condition = .init,
 
         /// Initializes a queue with fixed `capacity`.
         pub fn init(allocator: std.mem.Allocator, capacity: usize) !WorkQueue {
@@ -316,8 +316,8 @@ pub const ThreadPool = struct {
         ///
         /// Returns false when queue is at capacity.
         pub fn push(self: *WorkQueue, item: WorkItem) bool {
-            self.mutex.lock();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(Utils.io());
+            defer self.mutex.unlock(Utils.io());
 
             if (self.count >= self.capacity) {
                 return false;
@@ -326,14 +326,14 @@ pub const ThreadPool = struct {
             self.items[self.tail] = item;
             self.tail = (self.tail + 1) % self.capacity;
             self.count += 1;
-            self.condition.signal();
+            self.condition.signal(Utils.io());
             return true;
         }
 
         /// Pops one item from the queue, if available.
         pub fn pop(self: *WorkQueue) ?WorkItem {
-            self.mutex.lock();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(Utils.io());
+            defer self.mutex.unlock(Utils.io());
 
             return self.popUnlocked();
         }
@@ -388,12 +388,15 @@ pub const ThreadPool = struct {
 
         /// Waits up to `timeout_ns` for an item, then pops once.
         pub fn popWait(self: *WorkQueue, timeout_ns: u64) ?WorkItem {
-            self.mutex.lock();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(Utils.io());
+            defer self.mutex.unlock(Utils.io());
 
             // Wait for items if queue is empty
             if (self.count == 0) {
-                self.condition.timedWait(&self.mutex, timeout_ns) catch {};
+                const duration = std.Io.Duration.fromNanoseconds(@as(i96, @intCast(timeout_ns)));
+                self.mutex.unlock(Utils.io());
+                Utils.io().sleep(duration, .awake) catch {};
+                self.mutex.lockUncancelable(Utils.io());
             }
 
             // Pop while still holding the lock (no double-locking)
@@ -402,8 +405,8 @@ pub const ThreadPool = struct {
 
         /// Steals one item from the queue tail.
         pub fn steal(self: *WorkQueue) ?WorkItem {
-            self.mutex.lock();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(Utils.io());
+            defer self.mutex.unlock(Utils.io());
 
             if (self.count == 0) return null;
 
@@ -419,22 +422,22 @@ pub const ThreadPool = struct {
 
         /// Returns current queue depth.
         pub fn size(self: *WorkQueue) usize {
-            self.mutex.lock();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(Utils.io());
+            defer self.mutex.unlock(Utils.io());
             return self.count;
         }
 
         /// Returns true when the queue is full.
         pub fn isFull(self: *WorkQueue) bool {
-            self.mutex.lock();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(Utils.io());
+            defer self.mutex.unlock(Utils.io());
             return self.count >= self.capacity;
         }
 
         /// Removes all queued items.
         pub fn clear(self: *WorkQueue) void {
-            self.mutex.lock();
-            defer self.mutex.unlock();
+            self.mutex.lockUncancelable(Utils.io());
+            defer self.mutex.unlock(Utils.io());
             self.head = 0;
             self.tail = 0;
             self.count = 0;
@@ -549,10 +552,10 @@ pub const ThreadPool = struct {
         self.running.store(false, .release);
 
         // Signal all workers
-        self.work_queue.condition.broadcast();
+        self.work_queue.condition.broadcast(Utils.io());
         for (self.workers) |*worker| {
             worker.running.store(false, .release);
-            worker.local_queue.condition.broadcast();
+            worker.local_queue.condition.broadcast(Utils.io());
         }
 
         // Wait for workers to finish
@@ -620,8 +623,8 @@ pub const ThreadPool = struct {
         var submitted: usize = 0;
         const now = Utils.currentMillis();
 
-        self.work_queue.mutex.lock();
-        defer self.work_queue.mutex.unlock();
+        self.work_queue.mutex.lockUncancelable(Utils.io());
+        defer self.work_queue.mutex.unlock(Utils.io());
 
         for (tasks) |task| {
             if (self.work_queue.count >= self.work_queue.capacity) {
@@ -644,7 +647,7 @@ pub const ThreadPool = struct {
         }
 
         if (submitted > 0) {
-            self.work_queue.condition.broadcast();
+            self.work_queue.condition.broadcast(Utils.io());
         }
 
         return submitted;
@@ -669,7 +672,7 @@ pub const ThreadPool = struct {
                 }
 
                 if (attempts + 1 < attempts_limit and retry_delay_us > 0) {
-                    std.Thread.sleep(@as(u64, retry_delay_us) * Constants.TimeConstants.ns_per_us);
+                    Utils.sleepNs(@as(u64, retry_delay_us) * Constants.TimeConstants.ns_per_us);
                 }
             }
         }
@@ -685,7 +688,7 @@ pub const ThreadPool = struct {
         if (!self.work_queue.mutex.tryLock()) {
             return false;
         }
-        defer self.work_queue.mutex.unlock();
+        defer self.work_queue.mutex.unlock(Utils.io());
 
         if (self.work_queue.count >= self.work_queue.capacity) {
             _ = self.stats.tasks_dropped.fetchAdd(1, .monotonic);
@@ -703,7 +706,7 @@ pub const ThreadPool = struct {
         self.work_queue.count += 1;
 
         _ = self.stats.tasks_submitted.fetchAdd(1, .monotonic);
-        self.work_queue.condition.signal();
+        self.work_queue.condition.signal(Utils.io());
         return true;
     }
 
@@ -870,7 +873,7 @@ pub const ThreadPool = struct {
 
             if (completed + dropped >= submitted) break;
 
-            std.Thread.sleep(1 * Constants.TimeConstants.ns_per_ms);
+            Utils.sleepMs(1);
         }
     }
 
@@ -889,7 +892,7 @@ pub const ThreadPool = struct {
 
             if (hasTimedOut(started_at_ms, timeout_ms)) return false;
 
-            std.Thread.sleep(1 * Constants.TimeConstants.ns_per_ms);
+            Utils.sleepMs(1);
         }
     }
 
@@ -904,7 +907,7 @@ pub const ThreadPool = struct {
 
             if (hasTimedOut(started_at_ms, timeout_ms)) return false;
 
-            std.Thread.sleep(1 * Constants.TimeConstants.ns_per_ms);
+            Utils.sleepMs(1);
         }
     }
 
@@ -1024,7 +1027,7 @@ pub const ParallelSinkWriter = struct {
     config: ParallelConfig,
     sinks: std.ArrayList(SinkHandle),
     buffer: std.ArrayList([]const u8),
-    mutex: std.Thread.Mutex = .{},
+    mutex: std.Io.Mutex = .init,
     stats: ParallelStats = .{},
 
     pub const SinkHandle = struct {
@@ -1088,15 +1091,15 @@ pub const ParallelSinkWriter = struct {
 
     /// Add a sink for parallel writing.
     pub fn addSink(self: *ParallelSinkWriter, handle: SinkHandle) !void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         try self.sinks.append(self.allocator, handle);
     }
 
     /// Remove a sink by name.
     pub fn removeSink(self: *ParallelSinkWriter, name: []const u8) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         var i: usize = 0;
         while (i < self.sinks.items.len) {
@@ -1110,8 +1113,8 @@ pub const ParallelSinkWriter = struct {
 
     /// Enable or disable a sink by name.
     pub fn setSinkEnabled(self: *ParallelSinkWriter, name: []const u8, enabled: bool) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         for (self.sinks.items) |*sink| {
             if (std.mem.eql(u8, sink.name, name)) {
@@ -1134,8 +1137,8 @@ pub const ParallelSinkWriter = struct {
 
     /// Buffer a write for later dispatch.
     fn bufferWrite(self: *ParallelSinkWriter, data: []const u8) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         if (self.allocator.dupe(u8, data)) |data_copy| {
             self.buffer.append(self.allocator, data_copy) catch {
@@ -1152,8 +1155,8 @@ pub const ParallelSinkWriter = struct {
 
     /// Flush the buffer immediately.
     pub fn flushBuffer(self: *ParallelSinkWriter) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.flushBufferUnlocked();
     }
 
@@ -1167,8 +1170,8 @@ pub const ParallelSinkWriter = struct {
 
     /// Dispatch write to all sinks.
     fn dispatchWrite(self: *ParallelSinkWriter, data: []const u8) void {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
         self.dispatchWriteUnlocked(data);
     }
 
@@ -1265,8 +1268,8 @@ pub const ParallelSinkWriter = struct {
     pub fn flushAll(self: *ParallelSinkWriter) void {
         self.flushBuffer();
 
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         for (self.sinks.items) |sink| {
             if (sink.flush_fn) |flush_func| {
@@ -1287,8 +1290,8 @@ pub const ParallelSinkWriter = struct {
 
     /// Check if any sinks are enabled.
     pub fn hasEnabledSinks(self: *ParallelSinkWriter) bool {
-        self.mutex.lock();
-        defer self.mutex.unlock();
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
 
         for (self.sinks.items) |sink| {
             if (sink.enabled) return true;
@@ -1563,17 +1566,17 @@ test "thread pool priority ordering" {
     // Start the pool first so we can submit tasks
     try pool.start();
 
-    var order: std.ArrayList(u8) = .{};
+    var order: std.ArrayList(u8) = std.ArrayList(u8).empty;
     defer order.deinit(allocator);
-    var mutex = std.Thread.Mutex{};
+    var mutex: std.Io.Mutex = .init;
 
-    const Params = struct { o: *std.ArrayList(u8), m: *std.Thread.Mutex, val: u8, a: std.mem.Allocator };
+    const Params = struct { o: *std.ArrayList(u8), m: *std.Io.Mutex, val: u8, a: std.mem.Allocator };
     const OrderTask = struct {
         fn run(ctx: *anyopaque, _: ?std.mem.Allocator) void {
             const params: *Params = @ptrCast(@alignCast(ctx));
-            params.m.lock();
+            params.m.lockUncancelable(Utils.io());
             params.o.append(params.a, params.val) catch {};
-            params.m.unlock();
+            params.m.unlock(Utils.io());
         }
     };
 
@@ -1582,21 +1585,21 @@ test "thread pool priority ordering" {
     var p3: Params = .{ .o = &order, .m = &mutex, .val = 3, .a = allocator }; // Critical
 
     // Use a primary task to block the single worker thread
-    var block_mutex = std.Thread.Mutex{};
-    block_mutex.lock(); // Worker will block on this
+    var block_mutex: std.Io.Mutex = .init;
+    block_mutex.lockUncancelable(Utils.io()); // Worker will block on this
 
     const BlockTask = struct {
         fn run(ctx: *anyopaque, _: ?std.mem.Allocator) void {
-            const m: *std.Thread.Mutex = @ptrCast(@alignCast(ctx));
-            m.lock(); // Wait here
-            m.unlock();
+            const m: *std.Io.Mutex = @ptrCast(@alignCast(ctx));
+            m.lockUncancelable(Utils.io()); // Wait here
+            m.unlock(Utils.io());
         }
     };
 
     _ = pool.submit(.{ .callback = .{ .func = BlockTask.run, .context = &block_mutex } }, .critical);
 
     // Give it a moment to pick up the block task
-    std.Thread.sleep(10 * Constants.TimeConstants.ns_per_ms);
+    Utils.sleepMs(10);
 
     // Queue them up - they should be ordered in the queue by priority
     _ = pool.submit(.{ .callback = .{ .func = OrderTask.run, .context = &p1 } }, .normal);
@@ -1604,7 +1607,7 @@ test "thread pool priority ordering" {
     _ = pool.submit(.{ .callback = .{ .func = OrderTask.run, .context = &p3 } }, .critical);
 
     // Release the worker
-    block_mutex.unlock();
+    block_mutex.unlock(Utils.io());
     pool.waitAll();
 
     // Order should be 3, 2, 1
@@ -1640,23 +1643,23 @@ test "thread pool wait all timeout" {
 
     try pool.start();
 
-    var gate = std.Thread.Mutex{};
-    gate.lock();
+    var gate = std.Io.Mutex.init;
+    gate.lockUncancelable(Utils.io());
 
     const BlockTask = struct {
         fn run(ctx: *anyopaque, _: ?std.mem.Allocator) void {
-            const m: *std.Thread.Mutex = @ptrCast(@alignCast(ctx));
-            m.lock();
-            m.unlock();
+            const m: *std.Io.Mutex = @ptrCast(@alignCast(ctx));
+            m.lockUncancelable(Utils.io());
+            m.unlock(Utils.io());
         }
     };
 
     _ = pool.submit(.{ .callback = .{ .func = BlockTask.run, .context = &gate } }, .critical);
 
-    std.Thread.sleep(5 * Constants.TimeConstants.ns_per_ms);
+    Utils.sleepMs(5);
     try std.testing.expect(!pool.waitAllTimeout(10));
 
-    gate.unlock();
+    gate.unlock(Utils.io());
     try std.testing.expect(pool.waitAllTimeout(2_000));
 }
 
@@ -1774,7 +1777,7 @@ test "thread pool heavy concurrency stress loop" {
                 if (accepted) {
                     submitted += 1;
                 } else {
-                    std.Thread.sleep(50 * Constants.TimeConstants.ns_per_us);
+                    Utils.sleepNs(50 * Constants.TimeConstants.ns_per_us);
                 }
             }
         }

--- a/src/update_checker.zig
+++ b/src/update_checker.zig
@@ -21,6 +21,7 @@ const SemanticVersion = std.SemanticVersion;
 const version_info = @import("version.zig");
 const Network = @import("network.zig");
 const Constants = @import("constants.zig");
+const Utils = @import("utils.zig");
 
 /// GitHub repository owner for update checks.
 /// GitHub repository owner for update checks.
@@ -41,7 +42,7 @@ var update_check_done = false;
 var update_check_enabled = true;
 
 /// Mutex protecting the update check flag.
-var update_check_mutex = std.Thread.Mutex{};
+var update_check_mutex = std.Io.Mutex.init;
 
 /// Enables or disables update checking project-wide.
 /// Call this function before initializing any loggers to ensure it takes effect.
@@ -57,23 +58,23 @@ var update_check_mutex = std.Thread.Mutex{};
 /// const logger = logly.Logger.init(.{});
 /// ```
 pub fn setEnabled(enabled: bool) void {
-    update_check_mutex.lock();
-    defer update_check_mutex.unlock();
+    update_check_mutex.lockUncancelable(Utils.io());
+    defer update_check_mutex.unlock(Utils.io());
     update_check_enabled = enabled;
 }
 
 /// Returns whether update checking is enabled.
 pub fn isEnabled() bool {
-    update_check_mutex.lock();
-    defer update_check_mutex.unlock();
+    update_check_mutex.lockUncancelable(Utils.io());
+    defer update_check_mutex.unlock(Utils.io());
     return update_check_enabled;
 }
 
 /// Resets the update check state (useful for testing).
 /// This should only be called in test scenarios.
 pub fn resetState() void {
-    update_check_mutex.lock();
-    defer update_check_mutex.unlock();
+    update_check_mutex.lockUncancelable(Utils.io());
+    defer update_check_mutex.unlock(Utils.io());
     update_check_done = false;
     update_check_enabled = true;
 }
@@ -148,8 +149,8 @@ fn fetchLatestTag(allocator: std.mem.Allocator) ![]const u8 {
 /// Fails silently on errors (no internet, api limits, etc).
 /// Respects the project-wide update_check_enabled flag.
 pub fn checkForUpdates(allocator: std.mem.Allocator, global_console_display: bool) ?std.Thread {
-    update_check_mutex.lock();
-    defer update_check_mutex.unlock();
+    update_check_mutex.lockUncancelable(Utils.io());
+    defer update_check_mutex.unlock(Utils.io());
 
     // Prevent concurrent checks, running during tests, or when disabled project-wide
     if (update_check_done or builtin.is_test or !update_check_enabled) return null;
@@ -167,7 +168,7 @@ fn checkWorker(allocator: std.mem.Allocator, global_console_display: bool) void 
     // const reset = "\x1b[0m";
     // const bold_white = "\x1b[1;37m";
     // const red_bg = "\x1b[41m";
-    // std.log.info("{s}{s} [UPDATE ERROR] ❌ Failed to check for updates {s}", .{ bold_white, red_bg, reset });
+    // std.log.info("{s}{s} [UPDATE ERROR] âŒ Failed to check for updates {s}", .{ bold_white, red_bg, reset });
 
     const escape = "\x1b[";
     const reset = escape ++ Constants.Colors.reset ++ "m";

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -21,6 +21,60 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const Constants = @import("constants.zig");
+var threaded = std.Io.Threaded.init_single_threaded;
+
+pub fn io() std.Io {
+    return threaded.io();
+}
+
+/// Adapts an unmanaged `std.ArrayList(u8)` to the Zig 0.16 `std.Io.Writer` interface.
+pub const ArrayListWriter = struct {
+    writer: std.Io.Writer,
+    list: *std.ArrayList(u8),
+    allocator: std.mem.Allocator,
+
+    const vtable: std.Io.Writer.VTable = .{ .drain = drain };
+
+    pub fn init(list: *std.ArrayList(u8), allocator: std.mem.Allocator) ArrayListWriter {
+        return .{
+            .writer = .{
+                .vtable = &vtable,
+                .buffer = &.{},
+            },
+            .list = list,
+            .allocator = allocator,
+        };
+    }
+
+    fn drain(w: *std.Io.Writer, data: []const []const u8, splat: usize) std.Io.Writer.Error!usize {
+        const self: *ArrayListWriter = @fieldParentPtr("writer", w);
+        var written: usize = 0;
+        for (data) |bytes| {
+            self.list.appendSlice(self.allocator, bytes) catch return error.WriteFailed;
+            written += bytes.len;
+        }
+        if (splat == 0) {
+            const pattern = data[data.len - 1];
+            self.list.shrinkRetainingCapacity(self.list.items.len - pattern.len);
+            written -= pattern.len;
+        } else {
+            const pattern = data[data.len - 1];
+            for (1..splat) |_| {
+                self.list.appendSlice(self.allocator, pattern) catch return error.WriteFailed;
+                written += pattern.len;
+            }
+        }
+        return written;
+    }
+};
+
+fn nowReal() std.Io.Timestamp {
+    return std.Io.Clock.real.now(io());
+}
+
+fn nowMonotonic() std.Io.Timestamp {
+    return std.Io.Clock.awake.now(io());
+}
 
 /// Parses a size string (e.g., "10MB", "5GB") into bytes.
 /// Supports B, KB, MB, GB, TB (case insensitive).
@@ -80,10 +134,10 @@ pub fn writeSize(writer: anytype, bytes: u64) !void {
 /// Formats a byte size into a human-readable string.
 /// Uses the most appropriate unit (B, KB, MB, GB, TB).
 pub fn formatSize(allocator: std.mem.Allocator, bytes: u64) ![]u8 {
-    var list = std.ArrayList(u8).empty;
-    errdefer list.deinit(allocator);
-    try writeSize(list.writer(allocator), bytes);
-    return list.toOwnedSlice(allocator);
+    var writer = std.Io.Writer.Allocating.init(allocator);
+    errdefer writer.deinit();
+    try writeSize(&writer.writer, bytes);
+    return writer.toOwnedSlice();
 }
 
 /// Parses a duration string (e.g., "30s", "5m", "2h") into milliseconds.
@@ -142,10 +196,10 @@ pub fn writeDuration(writer: anytype, ms: i64) !void {
 
 /// Formats a duration in milliseconds into a human-readable string.
 pub fn formatDuration(allocator: std.mem.Allocator, ms: i64) ![]u8 {
-    var list = std.ArrayList(u8).empty;
-    errdefer list.deinit(allocator);
-    try writeDuration(list.writer(allocator), ms);
-    return list.toOwnedSlice(allocator);
+    var writer = std.Io.Writer.Allocating.init(allocator);
+    errdefer writer.deinit();
+    try writeDuration(&writer.writer, ms);
+    return writer.toOwnedSlice();
 }
 
 /// Time components extracted from an epoch timestamp.
@@ -309,22 +363,33 @@ pub fn writeUtcOffsetCompact(writer: anytype, offset_minutes: i16) !void {
 
 /// Gets current time components.
 pub fn nowComponents() TimeComponents {
-    return fromMilliTimestamp(std.time.milliTimestamp());
+    return fromMilliTimestamp(currentMillis());
 }
 
 /// Returns current Unix timestamp in seconds.
 pub fn currentSeconds() i64 {
-    return std.time.timestamp();
+    return nowReal().toSeconds();
 }
 
 /// Returns current timestamp in milliseconds.
 pub fn currentMillis() i64 {
-    return std.time.milliTimestamp();
+    return nowReal().toMilliseconds();
 }
 
 /// Returns current timestamp in nanoseconds.
 pub fn currentNanos() i128 {
-    return std.time.nanoTimestamp();
+    return @as(i128, nowMonotonic().toNanoseconds());
+}
+
+/// Sleeps for the specified duration in nanoseconds.
+pub fn sleepNs(duration_ns: u64) void {
+    const duration = std.Io.Duration.fromNanoseconds(@as(i96, @intCast(duration_ns)));
+    _ = std.Io.sleep(io(), duration, .awake) catch {};
+}
+
+/// Sleeps for the specified duration in milliseconds.
+pub fn sleepMs(duration_ms: u64) void {
+    sleepNs(duration_ms * Constants.TimeConstants.ns_per_ms);
 }
 
 /// Checks if two timestamps are on the same day.
@@ -355,7 +420,7 @@ pub fn startOfHour(timestamp: i64) i64 {
 
 /// Calculates elapsed time in milliseconds since start_time.
 pub fn elapsedMs(start_time: i64) u64 {
-    const now_time = std.time.milliTimestamp();
+    const now_time = currentMillis();
     if (now_time < start_time) return 0;
     return @intCast(now_time - start_time);
 }
@@ -456,16 +521,16 @@ fn formatDatePatternInternal(writer: anytype, fmt: []const u8, year: i32, month:
 
 /// Formats a date/time to a caller-provided buffer using a pattern.
 pub fn formatDateToBuf(buf: []u8, fmt: []const u8, year: i32, month: u8, day: u8, hour: u64, minute: u64, second: u64, millis: u64) ![]u8 {
-    var fbs = std.io.fixedBufferStream(buf);
-    try formatDatePattern(fbs.writer(), fmt, year, month, day, hour, minute, second, millis);
-    return fbs.getWritten();
+    var writer = std.Io.Writer.fixed(buf);
+    try formatDatePattern(&writer, fmt, year, month, day, hour, minute, second, millis);
+    return buf[0..writer.end];
 }
 
 /// Formats a date/time to a caller-provided buffer with timezone token support.
 pub fn formatDateToBufWithOffset(buf: []u8, fmt: []const u8, year: i32, month: u8, day: u8, hour: u64, minute: u64, second: u64, millis: u64, timezone_offset_minutes: i16) ![]u8 {
-    var fbs = std.io.fixedBufferStream(buf);
-    try formatDatePatternWithOffset(fbs.writer(), fmt, year, month, day, hour, minute, second, millis, timezone_offset_minutes);
-    return fbs.getWritten();
+    var writer = std.Io.Writer.fixed(buf);
+    try formatDatePatternWithOffset(&writer, fmt, year, month, day, hour, minute, second, millis, timezone_offset_minutes);
+    return buf[0..writer.end];
 }
 
 /// Writes an ISO 8601 date (YYYY-MM-DD) to the writer.
@@ -479,9 +544,9 @@ pub fn writeIsoDate(writer: anytype, tc: TimeComponents) !void {
 
 /// Formats an ISO 8601 date string (YYYY-MM-DD) to buffer.
 pub fn formatIsoDate(buf: []u8, tc: TimeComponents) ![]u8 {
-    var fbs = std.io.fixedBufferStream(buf);
-    try writeIsoDate(fbs.writer(), tc);
-    return fbs.getWritten();
+    var writer = std.Io.Writer.fixed(buf);
+    try writeIsoDate(&writer, tc);
+    return buf[0..writer.end];
 }
 
 /// Writes an ISO 8601 time (HH:MM:SS) to the writer.
@@ -495,9 +560,9 @@ pub fn writeIsoTime(writer: anytype, tc: TimeComponents) !void {
 
 /// Formats an ISO 8601 time string (HH:MM:SS) to buffer.
 pub fn formatIsoTime(buf: []u8, tc: TimeComponents) ![]u8 {
-    var fbs = std.io.fixedBufferStream(buf);
-    try writeIsoTime(fbs.writer(), tc);
-    return fbs.getWritten();
+    var writer = std.Io.Writer.fixed(buf);
+    try writeIsoTime(&writer, tc);
+    return buf[0..writer.end];
 }
 
 /// Writes an ISO 8601 datetime (YYYY-MM-DDTHH:MM:SS) to the writer.
@@ -509,9 +574,9 @@ pub fn writeIsoDateTime(writer: anytype, tc: TimeComponents) !void {
 
 /// Formats an ISO 8601 datetime string (YYYY-MM-DDTHH:MM:SS) to buffer.
 pub fn formatIsoDateTime(buf: []u8, tc: TimeComponents) ![]u8 {
-    var fbs = std.io.fixedBufferStream(buf);
-    try writeIsoDateTime(fbs.writer(), tc);
-    return fbs.getWritten();
+    var writer = std.Io.Writer.fixed(buf);
+    try writeIsoDateTime(&writer, tc);
+    return buf[0..writer.end];
 }
 
 /// Writes a filename-safe datetime (YYYY-MM-DD_HH-MM-SS) to the writer.
@@ -531,9 +596,9 @@ pub fn writeFilenameSafe(writer: anytype, tc: TimeComponents) !void {
 
 /// Formats a filename-safe datetime string (YYYY-MM-DD_HH-MM-SS) to buffer.
 pub fn formatFilenameSafe(buf: []u8, tc: TimeComponents) ![]u8 {
-    var fbs = std.io.fixedBufferStream(buf);
-    try writeFilenameSafe(fbs.writer(), tc);
-    return fbs.getWritten();
+    var writer = std.Io.Writer.fixed(buf);
+    try writeFilenameSafe(&writer, tc);
+    return buf[0..writer.end];
 }
 
 /// Clamps a value between min and max bounds.
@@ -574,7 +639,7 @@ pub const formatToBuf = formatDateToBuf;
 /// Example:
 /// ```zig
 /// var buf: [256]u8 = undefined;
-/// var fbs = std.io.fixedBufferStream(&buf);
+/// var writer = std.Io.Writer.fixed(&buf);
 /// try escapeJsonString(fbs.writer(), "Hello\nWorld");
 /// // Result: Hello\nWorld (with escaped newline)
 /// ```
@@ -610,9 +675,9 @@ pub fn escapeJsonString(writer: anytype, s: []const u8) !void {
 /// Returns:
 ///     Slice of written content
 pub fn escapeJsonStringToBuf(buf: []u8, s: []const u8) ![]u8 {
-    var fbs = std.io.fixedBufferStream(buf);
-    try escapeJsonString(fbs.writer(), s);
-    return fbs.getWritten();
+    var writer = std.Io.Writer.fixed(buf);
+    try escapeJsonString(&writer, s);
+    return buf[0..writer.end];
 }
 
 /// Calculates a rate as a floating-point ratio (0.0 - 1.0).
@@ -681,18 +746,18 @@ pub fn calculateThroughputMs(count: u64, elapsed_ms: i64) f64 {
 
 test "escapeJsonString" {
     var buf: [256]u8 = undefined;
-    var fbs = std.io.fixedBufferStream(&buf);
+    var writer = std.Io.Writer.fixed(&buf);
 
-    try escapeJsonString(fbs.writer(), "Hello\"World");
-    try std.testing.expectEqualStrings("Hello\\\"World", fbs.getWritten());
+    try escapeJsonString(&writer, "Hello\"World");
+    try std.testing.expectEqualStrings("Hello\\\"World", buf[0..writer.end]);
 
-    fbs.reset();
-    try escapeJsonString(fbs.writer(), "Line1\nLine2");
-    try std.testing.expectEqualStrings("Line1\\nLine2", fbs.getWritten());
+    writer.end = 0;
+    try escapeJsonString(&writer, "Line1\nLine2");
+    try std.testing.expectEqualStrings("Line1\\nLine2", buf[0..writer.end]);
 
-    fbs.reset();
-    try escapeJsonString(fbs.writer(), "Tab\there");
-    try std.testing.expectEqualStrings("Tab\\there", fbs.getWritten());
+    writer.end = 0;
+    try escapeJsonString(&writer, "Tab\there");
+    try std.testing.expectEqualStrings("Tab\\there", buf[0..writer.end]);
 }
 
 test "calculateRate" {
@@ -876,7 +941,7 @@ pub fn writeInt(writer: anytype, value: anytype) !void {
 /// Allocator is required to allocate the string.
 pub fn generateTraceId(allocator: std.mem.Allocator) ![]u8 {
     var bytes: [16]u8 = undefined;
-    std.crypto.random.bytes(&bytes);
+    io().random(&bytes);
     const hex_chars = "0123456789abcdef";
     var result = try allocator.alloc(u8, 32);
     for (bytes, 0..) |b, i| {
@@ -890,7 +955,7 @@ pub fn generateTraceId(allocator: std.mem.Allocator) ![]u8 {
 /// Allocator is required to allocate the string.
 pub fn generateSpanId(allocator: std.mem.Allocator) ![]u8 {
     var bytes: [8]u8 = undefined;
-    std.crypto.random.bytes(&bytes);
+    io().random(&bytes);
     const hex_chars = "0123456789abcdef";
     var result = try allocator.alloc(u8, 16);
     for (bytes, 0..) |b, i| {
@@ -979,7 +1044,9 @@ pub fn formatTraceparentHeader(allocator: std.mem.Allocator, trace_id: []const u
 pub fn shouldSample(rate: f64) bool {
     if (rate >= 1.0) return true;
     if (rate <= 0.0) return false;
-    return std.crypto.random.float(f64) < rate;
+    const rng_impl: std.Random.IoSource = .{ .io = io() };
+    const rng = rng_impl.interface();
+    return rng.float(f64) < rate;
 }
 
 test "generateTraceId" {
@@ -1139,7 +1206,7 @@ pub fn calculateRecordsPerSecond(records: u64, elapsed_ms: i64) f64 {
 ///
 /// Performance: O(1)
 pub fn durationSinceNs(start_time: i128) u64 {
-    const now = std.time.nanoTimestamp();
+    const now = currentNanos();
     if (now < start_time) return 0;
     return @intCast(@max(0, now - start_time));
 }
@@ -1427,7 +1494,7 @@ pub fn lzmaHash(data: []const u8, len: usize) u14 {
 }
 
 test "durationSinceNs" {
-    const start = std.time.nanoTimestamp();
+    const start = currentNanos();
     // Simple test - just verify duration is non-negative without sleep
     const duration = durationSinceNs(start);
     // Duration should be very small (microseconds to milliseconds) since we just started

--- a/src/version.zig
+++ b/src/version.zig
@@ -1,4 +1,4 @@
 //! Logly Version Information
 
-/// Logly V0.1.7 | Author: Muhammad Fiaz | License: MIT
-pub const version = "0.1.7";
+/// Logly V0.1.8 | Author: Muhammad Fiaz | License: MIT
+pub const version = "0.1.8";


### PR DESCRIPTION
## [0.1.8] - Zig 0.16.0 Compatibility

### Changed

- Migrated the project to Zig 0.16.0 and updated package metadata to require `minimum_zig_version = "0.16.0"`.
- Updated the public package version to `0.1.8`.
- Migrated standard library I/O usage to the Zig 0.16 `std.Io` APIs across file, network, terminal, stream, and writer paths.
- Updated allocator examples and documentation to use Zig 0.16-compatible `std.heap.DebugAllocator`.

### Fixed

- Fixed build system compatibility with Zig 0.16 package/dependency handling.
- Fixed examples that used removed or deprecated writer, filesystem, file-close, and stream APIs.
- Fixed Windows terminal ANSI enablement to use the cross-platform `std.Io.File.enableAnsiEscapeCodes` API.
- Fixed stack trace ownership so captured trace buffers are deinitialized safely under Zig 0.16.
- Fixed thread synchronization calls for Zig 0.16 `std.Io` lock APIs.

### Documentation

- Updated README installation, build, test, and usage snippets for Zig 0.16.0.
- Updated API and guide documentation for `std.Io.Reader`, `std.Io.Writer`, `std.Io.File`, `std.Io.Dir`, and `std.Io.net` usage.
- Updated all documented example snippets to avoid Zig 0.15-era filesystem, networking, and writer APIs.
