### PR TITLE
improved funcs and fixes issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,10 +57,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added file-based telemetry span export test coverage.
 - Added formatter template validation, metrics level reset, scheduler dependency validation, filter mode helper, rules count helper, and async backpressure tests.
 
-### Maintenance
-
-- Updated dependencies.
-- Applied formatting updates.
 
 ## [0.1.8] - Zig 0.16.0 Compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **Note:** Documentation for versions below 0.1.2 is not available. Please refer to commit history or pull requests for those versions.
 
+## [0.1.9]
+
+### Added
+
+- **Redaction truncate support**: new `RedactionType.truncate` with configurable `truncate_length` and `truncate_suffix` in `RedactionConfig`.
+- **Redaction hash selection**: configurable hash algorithm (`sha256`, `sha512`, `md5`) for hash-based redaction.
+- **Deterministic key sampling**: `Sampler.shouldSampleKey(...)` and `shouldSampleKeyWithReason(...)` for stable sampling decisions.
+- **Rotation time helpers**: `Rotation.nextRotationAt()` and `Rotation.rotationAgeSeconds()` with convenience aliases.
+- **Telemetry metrics export**: JSON and Prometheus metric exports with `TelemetryConfig.metrics_file_path` override.
+- **Telemetry metric naming controls**: `metric_prefix`, `metric_prefix_separator`, and `sanitize_metric_names` with config helpers for exporter-safe metric names.
+- **Pipeline configuration builders**: chainable helpers for async, thread pool, metrics, scheduler, rotation, rules, and full high-throughput/observability profiles.
+- **Metrics export customization**: configurable metric prefix, Prometheus/StatsD separators, sanitization, per-level export, and per-sink export breakdowns.
+- **Network send helpers**: `Network.sendTcp(...)` and `Network.sendSyslogUdp(...)` plus aliases.
+- **Formatter template validation**: `Formatter.validateTemplate(...)` and placeholder counting for custom format strings.
+- **Metrics level reset helper**: `Metrics.resetLevelMetrics(...)` for targeted level-counter resets.
+- **Scheduler dependency validation**: `Scheduler.validateDependencies(...)` to detect missing links and cycles.
+- **Filter mode helpers**: `Filter.setMode(...)` and `Filter.isMode(...)` for runtime mode control.
+- **Async backpressure tracking**: configurable backpressure threshold, effective batch-size clamping, and default drain timeout helpers.
+- **Rules count helpers**: `Rules.hasRules(...)` and `Rules.totalRuleCount(...)` for quick rule-set introspection.
+
+### Fixed
+
+- Fixed formatter theme precedence so sink/formatter custom themes are no longer masked by the default global color config.
+- Fixed file-based telemetry span and metrics exporters on Windows by opening append targets with read access before querying length.
+- Fixed `LogServer.stop()` shutdown behavior so TCP/UDP worker threads wake before join instead of hanging in network tests.
+- Corrected thread pool wait-time stats (ms to ns conversion) to prevent inflated averages.
+- Fixed async logging memory leak in the async pipeline.
+- Fixed aarch64 build/runtime compatibility issues.
+- Replaced comptime-only hex formatting in redaction hashing for Zig 0.16 runtime safety.
+
+### Documentation
+
+- Updated README and API/guide docs for redaction truncate, deterministic sampling, telemetry metric exports, rotation helpers, and network send helpers.
+- Added examples for new redaction, sampling, telemetry, rotation, and network helpers.
+- Added telemetry metric name prefix/sanitization example and docs.
+- Added pipeline controls example covering async, thread pool, metrics, scheduler, rotation, rules, and Prometheus export previews.
+- Refreshed telemetry docs to clarify file-based exporter output paths.
+- General docs refresh and maintenance updates.
+
+### Tests
+
+- Added formatter theme precedence regression tests.
+- Stabilized network send helper test shutdown and callback synchronization.
+- Added telemetry metric export format tests.
+- Added telemetry metric prefix/sanitization tests.
+- Added pipeline builder, metrics export naming/breakdown, async batch/backpressure, and Prometheus label escaping tests.
+- Added network send helper tests.
+- Added file-based telemetry span export test coverage.
+- Added formatter template validation, metrics level reset, scheduler dependency validation, filter mode helper, rules count helper, and async backpressure tests.
+
+### Maintenance
+
+- Updated dependencies.
+- Applied formatting updates.
+
 ## [0.1.8] - Zig 0.16.0 Compatibility
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A production-grade, high-performance structured logging library for Zig, designe
 - [Supported Platforms](#supported-platforms)
   - [Color Support](#color-support)
 - [Recent Changes](#recent-changes)
-    - [Version 0.1.8](#version-018)
+    - [Version 0.1.9](#version-019)
 - [Installation](#installation)
   - [Method 1: Zig Fetch (Recommended Stable)](#method-1-zig-fetch-recommended-stable)
   - [Method 2: Manual Configuration](#method-2-manual-configuration)
@@ -174,7 +174,7 @@ Before installing Logly, ensure you have the following:
 | **Terminal** | Any modern terminal | For colored output support |
 
 > Verify your Zig installation by running `zig version` in your terminal.
-> - For Zig 0.16.0+, use logly.zig version 0.1.8
+> - For Zig 0.16.0+, use logly.zig version 0.1.9
 > - For Zig 0.15.0, use logly.zig version 0.1.7
 
 ---
@@ -208,11 +208,22 @@ Logly.Zig supports a wide range of platforms and architectures:
 
 ## Recent Changes
 
-### Version 0.1.8
+### Version 0.1.9
 
 **Highlights:**
 
-- Migrated codebase to Zig 0.16 (from 0.15); updated examples, benchmarks, and vendored build scripts to match Zig 0.16 stdlib API changes. Documentation and examples were updated to reflect these API and build changes.
+- Added redaction truncate support and configurable hash algorithms.
+- Added deterministic key-based sampling helpers.
+- Added rotation time helpers (`nextRotationAt`, `rotationAgeSeconds`) with aliases.
+- Added telemetry metric export to JSON/Prometheus with `metrics_file_path` override.
+- Added telemetry metric prefixing and sanitization controls for exporter-compatible metric names.
+- Added library-wide pipeline controls for async, thread pool, metrics, scheduler, rotation, and rules composition.
+- Added metrics export naming/breakdown controls for Prometheus and StatsD output.
+- Added network send helpers for TCP and syslog UDP.
+- Fixed custom theme precedence, file-based telemetry exports on Windows, and network test/server shutdown.
+- Fixed async logging memory leak and aarch64 compatibility issues.
+- Refreshed docs and dependency maintenance updates.
+- Added formatter template validation, metrics level reset, scheduler dependency validation, filter mode helpers, async backpressure tracking, and rules count helpers.
 
 For a complete version history, see [CHANGELOG.md](CHANGELOG.md).
 
@@ -225,10 +236,10 @@ For a complete version history, see [CHANGELOG.md](CHANGELOG.md).
 
 The easiest way to add Logly to your project:
 
-**For Zig 0.16.0+ (Latest stable `0.1.8`):**
+**For Zig 0.16.0+ (Latest stable `0.1.9`):**
 
 ```bash
-zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz
+zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.9.tar.gz
 ```
 
 **For Zig 0.15.0 (Use `0.1.7`):**
@@ -256,7 +267,7 @@ Add to your `build.zig.zon`:
 ```zig
 .dependencies = .{
     .logly = .{
-        .url = "https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz",
+        .url = "https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.9.tar.gz",
         .hash = "...", // you needed to add hash here :)
     },
 },

--- a/build.zig
+++ b/build.zig
@@ -69,6 +69,8 @@ pub fn build(b: *std.Build) void {
         .{ .name = "config_presets", .path = "examples/config_presets.zig" },
         .{ .name = "rules", .path = "examples/rules.zig" },
         .{ .name = "telemetry", .path = "examples/telemetry.zig" },
+        .{ .name = "telemetry_metric_names", .path = "examples/telemetry_metric_names.zig" },
+        .{ .name = "pipeline_controls", .path = "examples/pipeline_controls.zig" },
     };
 
     // Create run-all-examples step that runs all examples sequentially

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .logly,
-    .version = "0.1.8",
+    .version = "0.1.9",
     .fingerprint = 0x54acba927bcb9891,
     .minimum_zig_version = "0.16.0",
     .dependencies = .{

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -16,7 +16,7 @@ export const ADSENSE_CLIENT_ID = "ca-pub-2040560600290490";
 
 // SEO Keywords
 export const KEYWORDS =
-  "zig, logging, logger, structured logging, async logging, json logging, file rotation, explicit rotation control, thread pool, scheduler, rules engine, diagnostics rules, metrics, tracing, telemetry, redaction, filtering, sampling, runtime sampling control, compression, zstd compression, queue utilization, distributed tracing, zig library, production logging, enterprise logging";
+  "zig, logging, logger, structured logging, async logging, json logging, file rotation, explicit rotation control, thread pool, scheduler, rules engine, diagnostics rules, metrics, metrics export, prometheus, tracing, telemetry, redaction, filtering, sampling, runtime sampling control, compression, zstd compression, queue utilization, distributed tracing, zig library, production logging, enterprise logging";
 
 export default defineConfig({
   lang: "en-US",
@@ -273,7 +273,7 @@ gtag('config', '${GA_ID}');`,
           priceCurrency: "USD",
         },
         downloadUrl: "https://github.com/muhammad-fiaz/logly.zig",
-        softwareVersion: "0.1.8",
+        softwareVersion: "0.1.9",
         license: "https://opensource.org/licenses/MIT",
       });
     } else {

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -155,6 +155,7 @@ Key fields:
 *   `api_key: ?[]const u8` -  API key for providers that require authentication.
 *   `connection_string: ?[]const u8` -  Connection string for Azure Application Insights.
 *   `exporter_file_path: ?[]const u8` -  File path for JSONL file exporter.
+*   `metrics_file_path: ?[]const u8` -  File path override for JSON/Prometheus metric exports.
 *   `batch_size: usize = Constants.TelemetryDefaults.batch_size` -  Batch span export size (default: 256).
 *   `batch_timeout_ms: u64 = Constants.TelemetryDefaults.batch_timeout_ms` -  Batch export timeout in ms (default: 5000).
 *   `sampling_strategy: SamplingStrategy` -  Sampling strategy (`.always_on`, `.always_off`, `.trace_id_ratio`, `.parent_based`).

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -91,6 +91,35 @@ The `Metrics` struct provides comprehensive observability into the logging syste
 
 Metrics tracks record counts, throughput, errors, and per-sink statistics. It uses thread-safe atomic operations for all counters, making it safe for concurrent access without locks on hot paths.
 
+## Export Customization
+
+`Config.MetricsConfig` now includes exporter naming and breakdown controls:
+
+```zig
+const cfg = logly.Config.MetricsConfig.production()
+    .prometheus()
+    .withPrefix("checkout.api")
+    .withLatencyHistogram(20)
+    .withBreakdowns(true, true);
+
+var metrics = logly.Metrics.initWithConfig(allocator, cfg);
+```
+
+Available controls:
+
+| Field / Helper | Purpose |
+|----------------|---------|
+| `metric_prefix`, `withPrefix()` / `prefix()` | Namespace exported metrics |
+| `metric_separator` | Separator for Prometheus-compatible names |
+| `statsd_separator` | Separator for StatsD metric names |
+| `sanitize_names` | Replace exporter-unsafe characters |
+| `export_level_breakdown` | Include per-level counters |
+| `export_sink_breakdown` | Include per-sink counters/errors |
+| `prometheus()` | Configure Prometheus export naming |
+| `statsd()` | Configure StatsD export naming |
+| `withAlerts()` / `alerts()` | Configure error/drop thresholds |
+| `withLatencyHistogram()` / `histogram()` | Enable latency histogram collection |
+
 ## Types
 
 ### Metrics

--- a/docs/api/network.md
+++ b/docs/api/network.md
@@ -32,6 +32,8 @@ The `Network` module provides utilities for network-based logging, including TCP
 | `connectTcp()` | `tcpConnect()`, `connect()` | Connect to TCP endpoint |
 | `createUdpSocket()` | `udpSocket()` | Create UDP socket |
 | `sendUdp()` | `udpSend()`, `sendToUdp()` | Send UDP message |
+| `sendTcp()` | `tcpSend()`, `sendToTcp()` | Send TCP message |
+| `sendSyslogUdp()` | `syslogSend()`, `sendSyslog()` | Send syslog message over UDP |
 | `fetchJson()` | `getJson()`, `httpGet()` | Fetch JSON from HTTP endpoint |
 | `init()` | `create()` | Initialize log server |
 | `deinit()` | `destroy()` | Deinitialize log server |
@@ -172,6 +174,14 @@ Creates a UDP socket connected to a host specified by a URI string (e.g., "udp:/
 
 Sends data via UDP socket.
 
+### `sendTcp(stream: std.Io.net.Stream, data: []const u8) !void`
+
+Sends data via TCP stream and updates network stats.
+
+### `sendSyslogUdp(allocator: std.mem.Allocator, socket: std.Io.net.Socket, address: std.Io.net.IpAddress, facility: SyslogFacility, severity: SyslogSeverity, hostname: []const u8, app_name: []const u8, message: []const u8) !void`
+
+Formats a syslog message and sends it over UDP.
+
 ### `fetchJson(allocator: std.mem.Allocator, url: []const u8, headers: []const http.Header) !std.json.Parsed(std.json.Value)`
 
 Fetches and parses a JSON response from a URL.
@@ -191,6 +201,10 @@ The Network module provides convenience aliases:
 | `udpSocket` | `createUdpSocket` |
 | `udpSend` | `sendUdp` |
 | `sendToUdp` | `sendUdp` |
+| `tcpSend` | `sendTcp` |
+| `sendToTcp` | `sendTcp` |
+| `syslogSend` | `sendSyslogUdp` |
+| `sendSyslog` | `sendSyslogUdp` |
 | `getJson` | `fetchJson` |
 | `httpGet` | `fetchJson` |
 | `syslogFormat` | `formatSyslog` |

--- a/docs/api/redactor.md
+++ b/docs/api/redactor.md
@@ -123,6 +123,7 @@ pub const RedactionType = enum {
     partial_end,    // 1234****
     hash,           // SHA256 hash
     mask_middle,    // 12****34
+    truncate,       // Truncate to N chars
     
     pub fn apply(self: RedactionType, allocator: Allocator, value: []const u8) ![]u8;
 };
@@ -197,6 +198,10 @@ pub const RedactionConfig = struct {
     enable_regex: bool = false,
     /// Hash algorithm for hash redaction type.
     hash_algorithm: HashAlgorithm = .sha256,
+    /// Maximum length before truncation (truncate redaction type).
+    truncate_length: usize = 24,
+    /// Suffix to append after truncation.
+    truncate_suffix: []const u8 = "...",
     /// Characters to reveal at start for partial redaction.
     partial_start_chars: u8 = 4,
     /// Characters to reveal at end for partial redaction.

--- a/docs/api/rotation.md
+++ b/docs/api/rotation.md
@@ -28,6 +28,8 @@ The `Rotation` module provides enterprise-grade log rotation capabilities, inclu
 | `getRotationReason()` | `rotationReason()`, `getReason()` | Get current rotation trigger reason |
 | `shouldRotate()` | `shouldRotateNow()` | Check if conditions currently require rotation |
 | `nextRotationInSeconds()` | `secondsUntilNextRotation()` | Get remaining interval seconds |
+| `nextRotationAt()` | `nextRotationAtSeconds()` | Get epoch seconds for next interval rotation |
+| `rotationAgeSeconds()` | `lastRotationAgeSeconds()` | Get seconds since last rotation |
 | `previewNextPath()` | `previewPath()`, `nextPath()` | Preview next rotated file path |
 | `forceRotate()` | `rotateNow()`, `force()` | Force rotation immediately |
 | `checkAndRotate()` | `rotateIfNeeded()`, `maybeRotate()` | Check and rotate if needed |
@@ -235,6 +237,14 @@ Returns true when any rotation condition is currently met.
 #### `nextRotationInSeconds(self: *const Rotation) ?i64`
 
 Returns remaining seconds until next interval rotation, or `null` if interval rotation is disabled.
+
+#### `nextRotationAt(self: *const Rotation) ?i64`
+
+Returns the epoch seconds when the next interval rotation would occur, or `null` if interval rotation is disabled.
+
+#### `rotationAgeSeconds(self: *const Rotation) i64`
+
+Returns the number of seconds since the last rotation.
 
 #### `previewNextPath(self: *Rotation) ![]u8`
 

--- a/docs/api/sampler.md
+++ b/docs/api/sampler.md
@@ -33,6 +33,8 @@ The `Sampler` struct controls log throughput by selectively processing records.
 | `totalAccepted()` | `accepted_()` | Get total accepted count |
 | `totalRejected()` | `rejected_()` | Get total rejected count |
 | `shouldSample()` | `sample()`, `check()`, `allow()` | Check if record should be sampled |
+| `shouldSampleKey()` | `sampleKey()` | Deterministic sampling decision for a key |
+| `shouldSampleKeyWithReason()` | `keyDecision()` | Deterministic sampling decision with reason |
 | `setStrategy()` | `configure()` | Update strategy at runtime |
 | `setProbability()` | `probability()`, `setProb()` | Set probability strategy with clamping |
 | `setRateLimit()` | `rateLimit()`, `configureRateLimit()` | Set rate-limit strategy |
@@ -158,6 +160,18 @@ Releases all resources associated with the sampler.
 Determines if the current record should be sampled (processed). Returns `true` to process, `false` to drop.
 
 **Alias**: `sample`, `check`, `allow`
+
+#### `shouldSampleKey(key: []const u8) bool`
+
+Deterministically samples based on a stable key (user/session/etc.).
+
+**Alias**: `sampleKey`
+
+#### `shouldSampleKeyWithReason(key: []const u8) SampleDecision`
+
+Deterministic sampling decision with reject reason details.
+
+**Alias**: `keyDecision`
 
 #### `shouldSampleWithReason() SampleDecision`
 

--- a/docs/api/telemetry.md
+++ b/docs/api/telemetry.md
@@ -10,6 +10,8 @@ Logly provides comprehensive OpenTelemetry (OTEL) support for distributed tracin
 - **Distributed Tracing**: Full W3C Trace Context specification support with parent-child span relationships
 - **W3C Baggage**: Context propagation for arbitrary key-value pairs across service boundaries
 - **Metrics Collection**: Counter, gauge, histogram, and summary metrics with configurable export formats
+- **Metrics Export Paths**: `metrics_file_path` overrides the default file exporter path for JSON/Prometheus metrics
+- **Metric Name Controls**: `metric_prefix`, `metric_prefix_separator`, and `sanitize_metric_names` normalize exported metric names for Prometheus-compatible output
 - **Network Export**: UDP/TCP/HTTP/gRPC transport protocols for span and metric export
 - **Export Modes**: Synchronous, async buffered, batch, and network export modes
 - **Span Processor Semantics**: `span_processor_type` affects export behavior: `.simple` keeps completed spans pending until an explicit `exportSpans()` or `flush()` call, while `.batch` will automatically export spans when the batch size or timeout is reached.
@@ -20,6 +22,37 @@ Logly provides comprehensive OpenTelemetry (OTEL) support for distributed tracin
 - **Custom Callbacks**: User-defined handlers for span lifecycle and metric events
 - **Thread Safety**: Mutex-protected concurrent access to spans and metrics
 - **Utils Integration**: Leverages utils.zig for ID generation, time calculations, and JSON escaping
+
+### Metric Export Formats
+
+```zig
+var config = logly.TelemetryConfig.development();
+config.metric_format = .json; // or .prometheus
+config.metrics_file_path = "telemetry_metrics.jsonl";
+
+var telemetry = try logly.Telemetry.init(allocator, config);
+defer telemetry.deinit();
+
+try telemetry.recordCounter("requests.total", 1.0);
+try telemetry.exportMetrics();
+```
+
+### Metric Name Prefixing and Sanitization
+
+```zig
+var config = logly.TelemetryConfig.development()
+    .withPrometheusMetrics("metrics.prom")
+    .withMetricPrefix("api.v1");
+config.metric_prefix_separator = ":";
+config.sanitize_metric_names = true;
+
+// "http.requests-total" exports as "api_v1:http_requests_total"
+try telemetry.recordCounter("http.requests-total", 1.0);
+```
+
+Sanitization replaces unsupported characters with `_` and protects names that
+start with digits. Disable it with `withMetricNameSanitization(false)` when a
+custom backend expects raw metric names.
 
 ## Quick Reference: Method Aliases
 

--- a/docs/api/update-checker.md
+++ b/docs/api/update-checker.md
@@ -169,9 +169,9 @@ pub fn main() !void {
 
 ## Recent Changes
 
-### v0.1.8
+### v0.1.9
 
-- Updated examples and version references to the latest release (`0.1.8`).
+- Updated examples and version references to the latest release (`0.1.9`).
 
 ### v0.1.8
 

--- a/docs/examples/metrics.md
+++ b/docs/examples/metrics.md
@@ -51,6 +51,25 @@ pub fn main() !void {
 }
 ```
 
+## Pipeline Controls Example
+
+Run the full pipeline-control example:
+
+```bash
+zig build run-pipeline_controls
+```
+
+It demonstrates chainable 0.1.9 configuration across async logging, thread pools, metrics exports, rules, scheduler maintenance, and rotation:
+
+```zig
+const config = logly.Config.default()
+    .withHighThroughputPipeline()
+    .withObservability("checkout.api")
+    .withAsync(logly.AsyncConfig.lowLatency().buffer(256).batch(8).backpressure(0.75))
+    .withThreadPool(logly.ThreadPoolConfig.ioBound().threads(4).queue(512).arena(true))
+    .withRotation(logly.Config.RotationConfig.daily(7).withCompression(.zstd));
+```
+
 ## Metrics Available
 
 ```zig

--- a/docs/examples/network-logging.md
+++ b/docs/examples/network-logging.md
@@ -93,6 +93,29 @@ nc -l -p 9000
 nc -u -l -p 9001
 ```
 
+## Helper APIs
+
+```zig
+const Network = logly.Network;
+
+const stream = try Network.connectTcp(allocator, "tcp://127.0.0.1:9000");
+defer stream.close(logly.Utils.io());
+try Network.sendTcp(stream, "raw tcp log\n");
+
+const udp = try Network.createUdpSocket(allocator, "udp://127.0.0.1:514");
+defer udp.socket.close(logly.Utils.io());
+try Network.sendSyslogUdp(
+  allocator,
+  udp.socket,
+  udp.address,
+  .user,
+  .info,
+  "localhost",
+  "my-app",
+  "syslog helper message",
+);
+```
+
 ## Best Practices
 
 1.  **Use JSON for Aggregators**: Most log management systems prefer structured data.

--- a/docs/examples/redaction.md
+++ b/docs/examples/redaction.md
@@ -114,6 +114,24 @@ const masked = try RedactionType.mask_middle.apply(allocator, "1234567890");
 // Result: "123****890"
 ```
 
+## Truncate and Hash Selection
+
+```zig
+var redactor = Redactor.init(allocator);
+defer redactor.deinit();
+
+redactor.config.truncate_length = 8;
+redactor.config.truncate_suffix = "...";
+redactor.config.hash_algorithm = .sha512;
+
+try redactor.addField("token", .truncate);
+try redactor.addField("user_id", .hash);
+
+const truncated = try redactor.redactField("token", "supersecretvalue");
+defer allocator.free(truncated);
+// truncated = "supersec..."
+```
+
 ## Redaction Presets
 
 ```zig

--- a/docs/examples/rotation.md
+++ b/docs/examples/rotation.md
@@ -45,6 +45,20 @@ _ = try logger.add(.{
 });
 ```
 
+## Rotation Helper Utilities
+
+```zig
+var rot = try logly.Rotation.init(allocator, "logs/app.log", "hourly", null, 7);
+defer rot.deinit();
+
+if (rot.nextRotationAt()) |epoch_seconds| {
+    std.debug.print("Next rotation at: {d}\n", .{epoch_seconds});
+}
+
+const age = rot.rotationAgeSeconds();
+std.debug.print("Last rotation age: {d}s\n", .{age});
+```
+
 ---
 
 ## Using Presets

--- a/docs/examples/sampling.md
+++ b/docs/examples/sampling.md
@@ -65,6 +65,17 @@ for (0..200) |i| {
 }
 ```
 
+## Deterministic Key Sampling
+
+```zig
+var sampler = Sampler.init(allocator, .{ .probability = 0.2 });
+defer sampler.deinit();
+
+if (sampler.shouldSampleKey("user-123")) {
+    std.debug.print("Deterministic sample\n", .{});
+}
+```
+
 ## Callbacks and Statistics
 
 You can monitor sampling behavior using callbacks and statistics.

--- a/docs/examples/telemetry.md
+++ b/docs/examples/telemetry.md
@@ -133,6 +133,32 @@ var config = logly.TelemetryConfig.file("telemetry_spans.jsonl");
 config.service_name = "dev-app";
 ```
 
+Note: the output path is relative to the current working directory. When running
+via `zig build run-telemetry`, this is often `zig-out/bin`.
+
+### Metric Name Controls
+
+```zig
+var config = logly.TelemetryConfig.development()
+    .withPrometheusMetrics("telemetry_metric_names.prom")
+    .withMetricPrefix("api.v1");
+config.metric_prefix_separator = ":";
+config.sanitize_metric_names = true;
+
+var telemetry = try logly.Telemetry.init(allocator, config);
+defer telemetry.deinit();
+
+try telemetry.recordCounter("http.requests-total", 42.0);
+try telemetry.recordGauge("99.cpu.usage", 73.5);
+try telemetry.exportMetrics();
+```
+
+Run the standalone example with:
+
+```bash
+zig build run-telemetry_metric_names
+```
+
 ### Custom Provider
 
 ```zig
@@ -274,6 +300,20 @@ try telemetry.recordGauge("memory.used_mb", 512.0);
 try telemetry.recordHistogram("latency_ms", 45.2);
 
 // Export metrics
+try telemetry.exportMetrics();
+```
+
+### Metric Export Formats
+
+```zig
+var config = logly.TelemetryConfig.development();
+config.metric_format = .json; // or .prometheus
+config.metrics_file_path = "telemetry_metrics.jsonl";
+
+var telemetry = try logly.Telemetry.init(allocator, config);
+defer telemetry.deinit();
+
+try telemetry.recordCounter("requests.total", 1.0);
 try telemetry.exportMetrics();
 ```
 

--- a/docs/guide/async.md
+++ b/docs/guide/async.md
@@ -85,6 +85,22 @@ When async logging is enabled, log messages follow this flow:
 3. **Batch Writing**: Messages are written in batches for efficiency
 4. **Flushing**: Buffers are flushed based on time or size
 
+The async stats object now also tracks backpressure events so you can see when the queue approaches capacity.
+
+The backpressure threshold and drain timeout are configurable:
+
+```zig
+const async_cfg = logly.AsyncConfig.lowLatency()
+    .buffer(2048)
+    .batch(32)
+    .backpressure(0.75);
+
+var async_logger = try logly.AsyncLogger.initWithConfig(allocator, async_cfg);
+defer async_logger.deinit();
+
+_ = async_logger.drainDefault(); // uses async_cfg.drain_timeout_ms
+```
+
 ## Configuration
 
 ### Logger Configuration
@@ -134,6 +150,8 @@ const config = logly.AsyncLogger.AsyncConfig{
 | `batch_size` | 64 | Messages written per batch |
 | `overflow_policy` | `.drop_oldest` | Behavior when buffer full |
 | `background_worker` | true | Enable background thread |
+| `backpressure_threshold` | 0.9 | Queue utilization ratio that records backpressure |
+| `drain_timeout_ms` | 5000 | Default timeout for `drainDefault()` |
 
 ## Overflow Policies
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -121,6 +121,7 @@ Notes:
 - `span_processor_type` semantics:
   - `.simple`: Completed spans are kept pending until you explicitly call `telemetry.exportSpans()` or `telemetry.flush()`. Use this when you want to control export timing (e.g., at request boundaries).
   - `.batch` : Spans are buffered and automatically exported when `batch_size` or `batch_timeout_ms` thresholds are reached.
+- `metrics_file_path` overrides `exporter_file_path` for JSON/Prometheus metric exports.
 - Default telemetry values (batch size, timeouts, headers) are centralized in `Constants.TelemetryDefaults`.
 - v0.1.8: Fixed an OTLP exporter compile-time issue (removed an unnecessary discard in `writeOtlpSpan`) so telemetry builds cleanly across targets.
 

--- a/docs/guide/filtering.md
+++ b/docs/guide/filtering.md
@@ -20,6 +20,8 @@ The `Filter` module allows you to:
 - Apply filters globally or per-sink
 - Use pre-built filter presets for common scenarios
 
+You can switch the runtime combination strategy with `filter.setMode(.any)`, `filter.setMode(.all)`, and related mode helpers.
+
 ## Basic Usage
 
 ```zig

--- a/docs/guide/formatting.md
+++ b/docs/guide/formatting.md
@@ -89,6 +89,8 @@ pub fn main() !void {
 
 You can customize the log output format using the `log_format` option in `Config` or `SinkConfig`.
 
+Use `Formatter.validateTemplate(...)` to check brace balance before deploying a custom format string.
+
 Supported tags:
 - `{time}`: Timestamp
 - `{level}`: Log level

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -22,10 +22,10 @@ Get started with Logly.zig in minutes.
 
 The easiest way to install Logly-Zig is using the `zig fetch` command:
 
-**For Zig 0.16.0+ (Latest stable `0.1.8`):**
+**For Zig 0.16.0+ (Latest stable `0.1.9`):**
 
 ```bash
-zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz
+zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.9.tar.gz
 ```
 
 **For Zig 0.15.0 (Use `0.1.7`):**
@@ -57,7 +57,7 @@ If you prefer manual installation, add to your `build.zig.zon`:
     .version = "0.1.0",
     .dependencies = .{
         .logly = .{
-            .url = "https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz",
+            .url = "https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.9.tar.gz",
             .hash = "1220...", // Run: zig fetch <url> to get this hash
         },
     },
@@ -83,7 +83,7 @@ To get the hash manually, run:
 
 **For Zig 0.16.0+:**
 ```bash
-zig fetch https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz
+zig fetch https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.9.tar.gz
 ```
 
 **For Zig 0.15.0:**
@@ -286,7 +286,7 @@ Both sets of methods are functionally identical.
 
 If you see a hash mismatch error, run:
 ```bash
-zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz
+zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.9.tar.gz
 ```
 
 ### Colors Not Displaying on Windows

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -20,10 +20,10 @@ This guide covers all available methods to install Logly.zig in your project.
 
 The easiest way to install Logly-Zig is using the `zig fetch` command:
 
-**For Zig 0.16.0+ (Latest stable `0.1.8`):**
+**For Zig 0.16.0+ (Latest stable `0.1.9`):**
 
 ```bash
-    zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz
+    zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.9.tar.gz
 ```
 
 **For Zig 0.15.0 (Use `0.1.7`):**
@@ -55,7 +55,7 @@ If you prefer manual installation, add to your `build.zig.zon`:
     .version = "0.1.0",
     .dependencies = .{
         .logly = .{
-            .url = "https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz",
+            .url = "https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.9.tar.gz",
             .hash = "1220...", // Run: zig fetch <url> to get this hash
         },
     },
@@ -81,7 +81,7 @@ To get the hash manually, run:
 
 **For Zig 0.16.0+:**
 ```bash
-zig fetch https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz
+zig fetch https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.9.tar.gz
 ```
 
 **For Zig 0.15.0:**
@@ -224,7 +224,7 @@ error: hash mismatch
 Update the hash in your `build.zig.zon` by running:
 
 ```bash
-zig fetch https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz
+zig fetch https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.9.tar.gz
 ```
 
 ### Module Not Found

--- a/docs/guide/metrics.md
+++ b/docs/guide/metrics.md
@@ -20,6 +20,24 @@ The `Metrics` module enables you to:
 - Measure logging throughput
 - Track per-sink statistics
 
+For targeted cleanup, `Metrics.resetLevelMetrics(level)` clears a single log-level counter without resetting the full collector.
+
+## Export Naming and Breakdowns
+
+Prometheus and StatsD exports can be namespaced and shaped from config:
+
+```zig
+const metrics_cfg = logly.Config.MetricsConfig.production()
+    .prometheus()
+    .prefix("api.gateway")
+    .histogram(20)
+    .breakdowns(true, true);
+
+var metrics = logly.Metrics.initWithConfig(allocator, metrics_cfg);
+```
+
+This produces exporter-safe names like `api_gateway_records_total` for Prometheus. Per-level and per-sink breakdowns are enabled by default and can be disabled when you need smaller exports.
+
 ## Basic Usage
 
 ```zig

--- a/docs/guide/network-logging.md
+++ b/docs/guide/network-logging.md
@@ -85,6 +85,31 @@ _ = try logger.addSink(sink);
 try logger.info("Hello from client!", .{});
 ```
 
+## Network Helper APIs
+
+Use the `Network` helpers directly when you need one-off sends outside of sinks:
+
+```zig
+const Network = logly.Network;
+
+const stream = try Network.connectTcp(allocator, "tcp://127.0.0.1:9000");
+defer stream.close(logly.Utils.io());
+try Network.sendTcp(stream, "raw tcp log\n");
+
+const udp = try Network.createUdpSocket(allocator, "udp://127.0.0.1:514");
+defer udp.socket.close(logly.Utils.io());
+try Network.sendSyslogUdp(
+  allocator,
+  udp.socket,
+  udp.address,
+  .user,
+  .info,
+  "localhost",
+  "my-app",
+  "syslog helper message",
+);
+```
+
 ## Reliability
 
 *   **Async Logging**: It is highly recommended to use `async_write = true` (default) for network sinks to avoid blocking your application if the network is slow or the server is unreachable.

--- a/docs/guide/redaction.md
+++ b/docs/guide/redaction.md
@@ -17,7 +17,7 @@ The `Redactor` module enables you to:
 - Automatically mask sensitive data in log messages
 - Define custom patterns for different data types
 - Use pattern matching: exact, prefix, suffix, contains, regex
-- Apply different redaction types: full, partial, hashed
+- Apply different redaction types: full, partial, hashed, truncate
 - Use pre-built presets for common compliance scenarios
 
 ## Basic Usage
@@ -137,6 +137,21 @@ try redactor.addField("patient_id", .hash);
 | `.partial_end` | `1234567890` | `1234******` |
 | `.mask_middle` | `1234567890` | `123****890` |
 | `.hash` | `sensitive` | `[HASH:a1b2c3d4...]` |
+| `.truncate` | `supersecretvalue` | `supersecre...` |
+
+### Truncation and Hash Selection
+
+```zig
+var redactor = Redactor.init(allocator);
+defer redactor.deinit();
+
+redactor.config.truncate_length = 8;
+redactor.config.truncate_suffix = "...";
+redactor.config.hash_algorithm = .sha512;
+
+try redactor.addField("token", .truncate);
+try redactor.addField("user_id", .hash);
+```
 
 ## Redaction Presets
 

--- a/docs/guide/rotation.md
+++ b/docs/guide/rotation.md
@@ -79,6 +79,20 @@ Rotates files when they reach a specific size limit.
 const config = SinkConfig.createSizeRotatingSink("app.log", 100 * 1024 * 1024, 10);
 ```
 
+### Rotation Helper APIs
+
+```zig
+var rot = try Rotation.init(allocator, "app.log", "hourly", null, 7);
+defer rot.deinit();
+
+if (rot.nextRotationAt()) |epoch_seconds| {
+    std.debug.print("Next rotation at: {d}\n", .{epoch_seconds});
+}
+
+const age = rot.rotationAgeSeconds();
+std.debug.print("Last rotation age: {d}s\n", .{age});
+```
+
 ### Sink Configuration Fields
 
 When using `logger.add(.{...})`, you can use the following fields to control rotation:

--- a/docs/guide/rules.md
+++ b/docs/guide/rules.md
@@ -95,6 +95,8 @@ Rules support multiple message categories, each with distinct styling:
 > [!NOTE]
 > The symbols shown above is the default configuration. You can customize these in `Config.RuleSymbols`.
 
+For introspection, `Rules.hasRules()` and `Rules.totalRuleCount()` report whether a rule set is configured and how many rules it contains.
+
 ### Creating Messages
 
 Use the convenient builder methods:

--- a/docs/guide/sampling.md
+++ b/docs/guide/sampling.md
@@ -133,6 +133,21 @@ var sampler = Sampler.init(allocator, .{ .adaptive = .{
 defer sampler.deinit();
 ```
 
+```
+
+### Deterministic Key Sampling
+
+Use a stable key (user/session/etc.) to get consistent decisions across requests:
+
+```zig
+var sampler = Sampler.init(allocator, .{ .probability = 0.2 });
+defer sampler.deinit();
+
+const should_log = sampler.shouldSampleKey("user-123");
+if (should_log) {
+    std.debug.print("Sampled log for user-123\n", .{});
+}
+```
 ## Monitoring and Callbacks
 
 You can register callbacks to monitor sampling decisions and rate adjustments:

--- a/docs/guide/scheduler.md
+++ b/docs/guide/scheduler.md
@@ -21,6 +21,8 @@ This guide covers automatic log maintenance in Logly using the scheduler, includ
 
 The scheduler module provides automatic log maintenance by running tasks on configurable schedules. This includes cleaning up old logs, compressing files, rotating logs, and running custom maintenance tasks.
 
+Use `Scheduler.validateDependencies()` after wiring tasks together to catch missing dependency names and dependency cycles early.
+
 ## Logger Configuration
 
 Enable scheduler through the Config struct:

--- a/docs/guide/telemetry.md
+++ b/docs/guide/telemetry.md
@@ -36,6 +36,7 @@ Logly's telemetry module integrates with:
 | **W3C Trace Context** | Full W3C traceparent/tracestate header support |
 | **W3C Baggage** | Context propagation across service boundaries |
 | **Metrics Collection** | Counter, gauge, histogram, and summary metrics |
+| **Metric Name Controls** | Prefix and sanitize exported metric names |
 | **Export Modes** | Sync, async buffer, batch, and network export |
 | **Custom Providers** | Build your own exporter with callback interface |
 | **Sampling Strategies** | always_on, always_off, trace_id_ratio, parent_based |
@@ -95,6 +96,30 @@ span.end();
 try telemetry.endSpan(&span);
 try telemetry.exportSpans();
 ```
+
+## Metric Export Names
+
+Prometheus and many telemetry backends accept a narrower metric-name character
+set than application code often uses. Logly can prefix and sanitize exported
+metric names while keeping the recorded name readable in application code.
+
+```zig
+var config = logly.TelemetryConfig.development()
+    .withPrometheusMetrics("telemetry_metrics.prom")
+    .withMetricPrefix("api.v1");
+config.metric_prefix_separator = ":";
+config.sanitize_metric_names = true;
+
+var telemetry = try logly.Telemetry.init(allocator, config);
+defer telemetry.deinit();
+
+try telemetry.recordCounter("http.requests-total", 42.0);
+try telemetry.exportMetrics();
+// Prometheus output: api_v1:http_requests_total 42
+```
+
+Set `sanitize_metric_names = false` or call
+`withMetricNameSanitization(false)` for custom exporters that require raw names.
 
 ## Supported Providers
 
@@ -223,6 +248,20 @@ try telemetry.recordHistogram("response.latency", 123.4);
 try telemetry.exportMetrics();
 ```
 
+### Metric Export Formats
+
+```zig
+var config = logly.TelemetryConfig.development();
+config.metric_format = .prometheus; // or .json
+config.metrics_file_path = "telemetry_metrics.prom";
+
+var telemetry = try logly.Telemetry.init(allocator, config);
+defer telemetry.deinit();
+
+try telemetry.recordGauge("cpu.usage", 42.0);
+try telemetry.exportMetrics();
+```
+
 ### Metric Kinds
 
 | Kind | Description | Use Case |
@@ -257,6 +296,8 @@ Monitor telemetry events:
 
 ```zig
 var config = logly.TelemetryConfig.file("spans.jsonl");
+
+// Output path is relative to the current working directory.
 
 config.on_span_start = struct {
     fn callback(span_id: []const u8, name: []const u8) void {

--- a/docs/guide/update-checker.md
+++ b/docs/guide/update-checker.md
@@ -83,12 +83,12 @@ pub fn main() !void {
 
 Newer version available:
 ```text
-info: [UPDATE] A newer release is available: v0.1.8 (current 0.1.6)
+info: [UPDATE] A newer release is available: v0.1.9 (current 0.1.8)
 ```
 
 Running a dev/nightly build:
 ```text
-info: [NIGHTLY] Running a dev/nightly build ahead of latest release: current 0.1.9, latest 0.1.8
+info: [NIGHTLY] Running a dev/nightly build ahead of latest release: current 0.1.10, latest 0.1.9
 ```
 
 ## Use Cases

--- a/docs/index.md
+++ b/docs/index.md
@@ -114,7 +114,7 @@ Logly.zig aims to be production-ready. While this is a relatively new project an
 The easiest way to add Logly to your project:
 
 ```bash
-zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.8.tar.gz
+zig fetch --save https://github.com/muhammad-fiaz/logly.zig/archive/refs/tags/0.1.9.tar.gz
 ```
 
 This automatically adds the dependency with the correct hash to your `build.zig.zon`.

--- a/examples/compression_demo.zig
+++ b/examples/compression_demo.zig
@@ -4,7 +4,7 @@ const logly = @import("logly");
 const Compression = logly.Compression;
 const CompressionPresets = logly.CompressionPresets;
 
-/// Comprehensive compression demo for Logly v0.1.8
+/// Comprehensive compression demo for Logly v0.1.9
 /// Demonstrates all compression algorithms: deflate, gzip, zlib, zstd, lzma, lzma2, xz, zip, tar.gz, lz4
 pub fn main() !void {
     var gpa = std.heap.DebugAllocator(.{}){};
@@ -13,7 +13,7 @@ pub fn main() !void {
 
     std.debug.print("\n", .{});
     std.debug.print("=" ** 70 ++ "\n", .{});
-    std.debug.print("  Logly Compression Demo v0.1.8\n", .{});
+    std.debug.print("  Logly Compression Demo v0.1.9\n", .{});
     std.debug.print("  All Compression Algorithms: deflate, gzip, zstd, lzma, xz, zip, tar.gz, lz4\n", .{});
     std.debug.print("=" ** 70 ++ "\n\n", .{});
 

--- a/examples/custom_colors.zig
+++ b/examples/custom_colors.zig
@@ -12,7 +12,7 @@ pub fn main() !void {
     const logger = try logly.Logger.init(allocator);
     defer logger.deinit();
 
-    std.debug.print("=== Color System Demo (v0.1.8) ===\n\n", .{});
+    std.debug.print("=== Color System Demo (v0.1.9) ===\n\n", .{});
 
     // Basic custom levels with ANSI codes
     try logger.addCustomLevel("NOTICE", 22, "36;1");
@@ -50,7 +50,7 @@ pub fn main() !void {
     try logger.custom("ALERT", "Alert (Red Underline)", @src());
     try logger.custom("HIGHLIGHT", "Highlight (Yellow Bold Reverse)", @src());
 
-    std.debug.print("\n=== Level Color Variants (v0.1.8) ===\n\n", .{});
+    std.debug.print("\n=== Level Color Variants (v0.1.9) ===\n\n", .{});
 
     // Demonstrate color variants available on each level
     const Level = logly.Level;
@@ -124,7 +124,7 @@ pub fn main() !void {
     std.debug.print("  trace={s} debug={s} info={s}\n", .{ neon.trace, neon.debug, neon.info });
     std.debug.print("  success={s} warning={s} err={s}\n", .{ neon.success, neon.warning, neon.err });
 
-    std.debug.print("\n=== Advanced CustomLevel (v0.1.8) ===\n\n", .{});
+    std.debug.print("\n=== Advanced CustomLevel (v0.1.9) ===\n\n", .{});
 
     // Demonstrate advanced CustomLevel creation
     const CustomLevel = logly.CustomLevel;

--- a/examples/custom_theme.zig
+++ b/examples/custom_theme.zig
@@ -14,7 +14,7 @@ pub fn main() !void {
 
     const Theme = logly.Formatter.Theme;
 
-    std.debug.print("\n=== Theme Presets (v0.1.8) ===\n\n", .{});
+    std.debug.print("\n=== Theme Presets (v0.1.9) ===\n\n", .{});
 
     // Built-in theme presets
     std.debug.print("Available presets:\n", .{});

--- a/examples/network_send_helpers.zig
+++ b/examples/network_send_helpers.zig
@@ -1,0 +1,25 @@
+const std = @import("std");
+const logly = @import("logly");
+
+pub fn main() !void {
+    var gpa = std.heap.DebugAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const stream = try logly.Network.connectTcp(allocator, "tcp://127.0.0.1:9000");
+    defer stream.close(logly.Utils.io());
+    try logly.Network.sendTcp(stream, "raw tcp log\n");
+
+    const udp = try logly.Network.createUdpSocket(allocator, "udp://127.0.0.1:514");
+    defer udp.socket.close(logly.Utils.io());
+    try logly.Network.sendSyslogUdp(
+        allocator,
+        udp.socket,
+        udp.address,
+        .user,
+        .info,
+        "localhost",
+        "logly-demo",
+        "syslog helper message",
+    );
+}

--- a/examples/pipeline_controls.zig
+++ b/examples/pipeline_controls.zig
@@ -1,0 +1,52 @@
+const std = @import("std");
+const logly = @import("logly");
+
+pub fn main() !void {
+    var gpa = std.heap.DebugAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    std.debug.print("=== Logly Pipeline Controls (v0.1.9) ===\n\n", .{});
+
+    const config = logly.Config.default()
+        .withHighThroughputPipeline()
+        .withObservability("checkout.api")
+        .withAsync(logly.AsyncConfig.lowLatency().buffer(256).batch(8).backpressure(0.75))
+        .withThreadPool(logly.ThreadPoolConfig.ioBound().threads(4).queue(512).arena(true))
+        .withRotation(logly.Config.RotationConfig.daily(7).withCompression(.zstd))
+        .withScheduler(logly.SchedulerConfig.maintenance("logs/archive").cleanupDays(14).retainFiles(100));
+
+    std.debug.print("Async enabled:       {s}\n", .{if (config.async_config.enabled) "yes" else "no"});
+    std.debug.print("Async buffer:        {d}\n", .{config.async_config.buffer_size});
+    std.debug.print("Async batch:         {d}\n", .{config.async_config.batch_size});
+    std.debug.print("Backpressure at:     {d:.2}\n", .{config.async_config.backpressure_threshold});
+    std.debug.print("Thread pool enabled: {s}\n", .{if (config.thread_pool.enabled) "yes" else "no"});
+    std.debug.print("Thread count:        {d}\n", .{config.thread_pool.thread_count});
+    std.debug.print("Metrics format:      {s}\n", .{@tagName(config.metrics.export_format)});
+    std.debug.print("Metrics prefix:      {s}\n", .{config.metrics.metric_prefix});
+    std.debug.print("Rules enabled:       {s}\n", .{if (config.rules.enabled) "yes" else "no"});
+    std.debug.print("Rotation interval:   {s}\n", .{config.rotation.interval orelse "none"});
+    std.debug.print("Rotation compression:{s}\n", .{@tagName(config.rotation.compression_algorithm)});
+    std.debug.print("Scheduler enabled:   {s}\n\n", .{if (config.scheduler.enabled) "yes" else "no"});
+
+    var metrics = logly.Metrics.initWithConfig(allocator, config.metrics);
+    defer metrics.deinit();
+
+    const file_sink = try metrics.addSink("file:application.log");
+    metrics.recordLog(.info, 120);
+    metrics.recordLogWithLatency(.err, 64, 1_500_000);
+    metrics.recordSinkWrite(file_sink, 184);
+    metrics.recordSinkFlush(file_sink);
+
+    const prometheus = try metrics.exportPrometheus(allocator);
+    defer allocator.free(prometheus);
+
+    std.debug.print("--- Prometheus Export Preview ---\n{s}\n", .{prometheus});
+
+    var async_logger = try logly.AsyncLogger.initWithConfig(allocator, config.async_config);
+    defer async_logger.deinit();
+
+    _ = async_logger.queue("queued through async pipeline", @intFromEnum(logly.Level.info));
+    _ = async_logger.drainDefault();
+    std.debug.print("Async queue drained: {s}\n", .{if (async_logger.isQueueEmpty()) "yes" else "no"});
+}

--- a/examples/redaction_truncate.zig
+++ b/examples/redaction_truncate.zig
@@ -1,0 +1,27 @@
+const std = @import("std");
+const logly = @import("logly");
+
+pub fn main() !void {
+    var gpa = std.heap.DebugAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var redactor = logly.Redactor.init(allocator);
+    defer redactor.deinit();
+
+    redactor.config.truncate_length = 8;
+    redactor.config.truncate_suffix = "...";
+    redactor.config.hash_algorithm = .sha512;
+
+    try redactor.addField("token", .truncate);
+    try redactor.addField("user_id", .hash);
+
+    const truncated = try redactor.redactField("token", "supersecretvalue");
+    defer allocator.free(truncated);
+
+    const hashed = try redactor.redactField("user_id", "user-123");
+    defer allocator.free(hashed);
+
+    std.debug.print("Truncated: {s}\n", .{truncated});
+    std.debug.print("Hashed: {s}\n", .{hashed});
+}

--- a/examples/rotation_helpers.zig
+++ b/examples/rotation_helpers.zig
@@ -1,0 +1,20 @@
+const std = @import("std");
+const logly = @import("logly");
+
+pub fn main() !void {
+    var gpa = std.heap.DebugAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var rotation = try logly.Rotation.init(allocator, "logs/app.log", "hourly", null, 7);
+    defer rotation.deinit();
+
+    if (rotation.nextRotationAt()) |epoch_seconds| {
+        std.debug.print("Next rotation at: {d}\n", .{epoch_seconds});
+    } else {
+        std.debug.print("Interval rotation disabled\n", .{});
+    }
+
+    const age = rotation.rotationAgeSeconds();
+    std.debug.print("Last rotation age: {d}s\n", .{age});
+}

--- a/examples/sampling_key.zig
+++ b/examples/sampling_key.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+const logly = @import("logly");
+
+pub fn main() !void {
+    var gpa = std.heap.DebugAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var sampler = logly.Sampler.init(allocator, .{ .probability = 0.2 });
+    defer sampler.deinit();
+
+    const users = [_][]const u8{ "user-123", "user-456", "user-789" };
+    for (users) |user| {
+        const decision = sampler.shouldSampleKey(user);
+        std.debug.print("{s}: {s}\n", .{ user, if (decision) "sample" else "skip" });
+    }
+}

--- a/examples/scheduler_demo.zig
+++ b/examples/scheduler_demo.zig
@@ -16,7 +16,7 @@ pub fn main() !void {
     const allocator = gpa.allocator();
 
     std.debug.print("\n", .{});
-    std.debug.print("Logly Scheduler Demo v0.1.8\n", .{});
+    std.debug.print("Logly Scheduler Demo v0.1.9\n", .{});
     std.debug.print("Automated Tasks with Compression Integration\n\n", .{});
 
     // Create logs directory for testing

--- a/examples/telemetry.zig
+++ b/examples/telemetry.zig
@@ -87,10 +87,6 @@ fn fileBasedTelemetry(allocator: std.mem.Allocator) !void {
         .kind = .server,
     });
     defer span.deinit();
-    defer {
-        span.end();
-        _ = telemetry.endSpan(&span) catch {};
-    }
 
     try span.setAttribute("http.method", logly.SpanAttribute{ .string = "GET" });
     try span.setAttribute("http.url", logly.SpanAttribute{ .string = "/api/users" });
@@ -100,6 +96,8 @@ fn fileBasedTelemetry(allocator: std.mem.Allocator) !void {
     try span.addEvent("database_query", null);
     try span.addEvent("response_sent", null);
 
+    span.end();
+    try telemetry.endSpan(&span);
     try telemetry.exportSpans();
 
     std.debug.print("✓ File-based telemetry configured\n", .{});

--- a/examples/telemetry_metric_names.zig
+++ b/examples/telemetry_metric_names.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+const logly = @import("logly");
+
+pub fn main() !void {
+    var gpa = std.heap.DebugAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const metrics_path = "telemetry_metric_names.prom";
+
+    var config = logly.TelemetryConfig.development()
+        .withPrometheusMetrics(metrics_path)
+        .withMetricPrefix("api.v1");
+    config.metric_prefix_separator = ":";
+    config.sanitize_metric_names = true;
+
+    var telemetry = try logly.Telemetry.init(allocator, config);
+    defer telemetry.deinit();
+
+    try telemetry.recordCounter("http.requests-total", 42.0);
+    try telemetry.recordGauge("99.cpu.usage", 73.5);
+    try telemetry.exportMetrics();
+
+    std.debug.print("Telemetry metric names exported to {s}\n", .{metrics_path});
+    std.debug.print("Sanitized examples:\n", .{});
+    std.debug.print("  api.v1:http.requests-total -> api_v1:http_requests_total\n", .{});
+    std.debug.print("  api.v1:99.cpu.usage       -> api_v1:_99_cpu_usage\n", .{});
+}

--- a/examples/telemetry_metrics_export.zig
+++ b/examples/telemetry_metrics_export.zig
@@ -1,0 +1,21 @@
+const std = @import("std");
+const logly = @import("logly");
+
+pub fn main() !void {
+    var gpa = std.heap.DebugAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var config = logly.TelemetryConfig.development();
+    config.metric_format = .json;
+    config.metrics_file_path = "telemetry_metrics.jsonl";
+
+    var telemetry = try logly.Telemetry.init(allocator, config);
+    defer telemetry.deinit();
+
+    try telemetry.recordCounter("requests.total", 1.0);
+    try telemetry.recordGauge("cpu.usage", 42.0);
+    try telemetry.exportMetrics();
+
+    std.debug.print("Metrics exported to {s}\n", .{config.metrics_file_path.?});
+}

--- a/src/async.zig
+++ b/src/async.zig
@@ -114,6 +114,8 @@ pub const AsyncLogger = struct {
         records_dropped: std.atomic.Value(Constants.AtomicUnsigned) = std.atomic.Value(Constants.AtomicUnsigned).init(0),
         /// Number of buffer overflow events.
         buffer_overflows: std.atomic.Value(Constants.AtomicUnsigned) = std.atomic.Value(Constants.AtomicUnsigned).init(0),
+        /// Number of times the queue entered a high-utilization backpressure range.
+        backpressure_events: std.atomic.Value(Constants.AtomicUnsigned) = std.atomic.Value(Constants.AtomicUnsigned).init(0),
         /// Number of flush operations performed.
         flush_count: std.atomic.Value(Constants.AtomicUnsigned) = std.atomic.Value(Constants.AtomicUnsigned).init(0),
         /// Total latency in nanoseconds.
@@ -176,6 +178,11 @@ pub const AsyncLogger = struct {
             return Utils.atomicLoadU64(&self.buffer_overflows);
         }
 
+        /// Returns backpressure event count as u64.
+        pub fn getBackpressureEvents(self: *const AsyncStats) u64 {
+            return Utils.atomicLoadU64(&self.backpressure_events);
+        }
+
         /// Checks if any records have been dropped.
         pub fn hasDropped(self: *const AsyncStats) bool {
             return self.records_dropped.load(.monotonic) > 0;
@@ -184,6 +191,11 @@ pub const AsyncLogger = struct {
         /// Checks if any buffer overflows occurred.
         pub fn hasOverflows(self: *const AsyncStats) bool {
             return self.buffer_overflows.load(.monotonic) > 0;
+        }
+
+        /// Checks if any backpressure events occurred.
+        pub fn hasBackpressureEvents(self: *const AsyncStats) bool {
+            return self.backpressure_events.load(.monotonic) > 0;
         }
 
         /// Calculate write success rate (0.0 - 1.0).
@@ -200,6 +212,8 @@ pub const AsyncLogger = struct {
 
         /// Alias for inFlight
         pub const pendingRecords = inFlight;
+        /// Alias for getBackpressureEvents.
+        pub const backpressureCount = getBackpressureEvents;
     };
 
     /// Represents a single log entry within the ring buffer.
@@ -395,6 +409,12 @@ pub const AsyncLogger = struct {
         }
     }
 
+    /// Returns the effective batch size after clamping configuration to the static buffer.
+    pub fn effectiveBatchSize(self: *const AsyncLogger) usize {
+        if (self.config.batch_size == 0) return 1;
+        return @min(self.config.batch_size, Constants.AsyncConstants.batch_size);
+    }
+
     /// Registers a new sink for log output.
     /// Thread-safe.
     pub fn addSink(self: *AsyncLogger, sink: *Sink) !void {
@@ -494,6 +514,20 @@ pub const AsyncLogger = struct {
                 if (self.buffer.push(entry)) {
                     _ = self.stats.records_queued.fetchAdd(1, .monotonic);
 
+                    const threshold = if (self.config.backpressure_threshold < 0.0)
+                        0.0
+                    else if (self.config.backpressure_threshold > 1.0)
+                        1.0
+                    else
+                        self.config.backpressure_threshold;
+                    const queue_load = if (self.buffer.capacity == 0)
+                        0.0
+                    else
+                        @as(f64, @floatFromInt(self.buffer.count)) / @as(f64, @floatFromInt(self.buffer.capacity));
+                    if (queue_load >= threshold) {
+                        _ = self.stats.backpressure_events.fetchAdd(1, .monotonic);
+                    }
+
                     // Update max queue depth
                     const current = self.buffer.size();
                     var max = self.stats.max_queue_depth.load(.monotonic);
@@ -551,12 +585,13 @@ pub const AsyncLogger = struct {
         defer self.mutex.unlock(Utils.io());
 
         var batch: [Constants.AsyncConstants.batch_size]BufferEntry = undefined;
+        const batch_limit = self.effectiveBatchSize();
         const start_time = Utils.currentMillis();
         var total_flushed: u64 = 0;
         var total_bytes: u64 = 0;
 
         while (true) {
-            const count = self.buffer.popBatch(&batch);
+            const count = self.buffer.popBatch(batch[0..batch_limit]);
             if (count == 0) break;
 
             for (batch[0..count]) |entry| {
@@ -597,6 +632,7 @@ pub const AsyncLogger = struct {
         }
 
         var batch: [Constants.AsyncConstants.batch_size]BufferEntry = undefined;
+        const batch_limit = self.effectiveBatchSize();
         var last_flush = Utils.currentMillis();
 
         while (self.running.load(.acquire) or !self.buffer.isEmpty()) {
@@ -620,7 +656,7 @@ pub const AsyncLogger = struct {
             }
 
             // Process batch
-            const count = self.buffer.popBatch(&batch);
+            const count = self.buffer.popBatch(batch[0..batch_limit]);
             self.mutex.unlock(Utils.io());
 
             if (count > 0) {
@@ -754,6 +790,11 @@ pub const AsyncLogger = struct {
         }
     }
 
+    /// Waits for the queue to drain using the configured drain timeout.
+    pub fn waitUntilDrainedDefault(self: *AsyncLogger) bool {
+        return self.waitUntilDrained(self.config.drain_timeout_ms);
+    }
+
     /// Sets overflow callback.
     pub fn setOverflowCallback(self: *AsyncLogger, callback: *const fn (u64) void) void {
         self.overflow_callback = callback;
@@ -845,6 +886,7 @@ pub const AsyncLogger = struct {
     /// Alias for waitUntilDrained
     pub const waitForDrain = waitUntilDrained;
     pub const drain = waitUntilDrained;
+    pub const drainDefault = waitUntilDrainedDefault;
 
     /// Alias for isQueueEmpty
     pub const empty = isQueueEmpty;
@@ -1206,4 +1248,45 @@ test "async queue utilization and drain helpers" {
 
     logger.flushSync();
     try std.testing.expect(logger.waitUntilDrained(25));
+    try std.testing.expect(logger.drainDefault());
+}
+
+test "async backpressure events" {
+    const allocator = std.testing.allocator;
+
+    const config = AsyncLogger.AsyncConfig{
+        .buffer_size = 2,
+        .background_worker = false,
+        .overflow_policy = .drop_newest,
+        .backpressure_threshold = 0.5,
+    };
+
+    var logger = try AsyncLogger.initWithConfig(allocator, config);
+    defer logger.deinit();
+
+    _ = logger.queue("alpha", 1);
+    _ = logger.queue("beta", 1);
+
+    try std.testing.expect(logger.stats.hasBackpressureEvents());
+    try std.testing.expect(logger.stats.getBackpressureEvents() > 0);
+    try std.testing.expect(logger.stats.backpressureCount() > 0);
+}
+
+test "async effective batch size respects config" {
+    const allocator = std.testing.allocator;
+
+    var logger = try AsyncLogger.initWithConfig(allocator, .{
+        .buffer_size = 8,
+        .batch_size = 3,
+        .background_worker = false,
+    });
+    defer logger.deinit();
+
+    try std.testing.expectEqual(@as(usize, 3), logger.effectiveBatchSize());
+
+    logger.config.batch_size = 0;
+    try std.testing.expectEqual(@as(usize, 1), logger.effectiveBatchSize());
+
+    logger.config.batch_size = Constants.AsyncConstants.batch_size * 4;
+    try std.testing.expectEqual(Constants.AsyncConstants.batch_size, logger.effectiveBatchSize());
 }

--- a/src/config.zig
+++ b/src/config.zig
@@ -410,18 +410,7 @@ pub const Config = struct {
         /// Get the effective color for a level, considering theme and overrides.
         pub fn getColorForLevel(self: LevelColorConfig, level: Level) []const u8 {
             // Check individual overrides first
-            const override = switch (level) {
-                .trace => self.trace_color,
-                .debug => self.debug_color,
-                .info => self.info_color,
-                .notice => self.notice_color,
-                .success => self.success_color,
-                .warning => self.warning_color,
-                .err => self.error_color,
-                .fail => self.fail_color,
-                .critical => self.critical_color,
-                .fatal => self.fatal_color,
-            };
+            const override = self.getOverrideForLevel(level);
             if (override) |color| return color;
 
             // Fall back to theme colors
@@ -475,6 +464,47 @@ pub const Config = struct {
                 },
                 .none => "",
             };
+        }
+
+        /// Returns the explicit per-level color override, if one is configured.
+        pub fn getOverrideForLevel(self: LevelColorConfig, level: Level) ?[]const u8 {
+            return switch (level) {
+                .trace => self.trace_color,
+                .debug => self.debug_color,
+                .info => self.info_color,
+                .notice => self.notice_color,
+                .success => self.success_color,
+                .warning => self.warning_color,
+                .err => self.error_color,
+                .fail => self.fail_color,
+                .critical => self.critical_color,
+                .fatal => self.fatal_color,
+            };
+        }
+
+        /// Returns true when a level has an explicit per-level color override.
+        pub fn hasOverrideForLevel(self: LevelColorConfig, level: Level) bool {
+            return self.getOverrideForLevel(level) != null;
+        }
+
+        /// Returns true when the color configuration is still using the default theme.
+        pub fn usesDefaultTheme(self: LevelColorConfig) bool {
+            return self.theme_preset == .default;
+        }
+
+        /// Returns true when no explicit theme or per-level override is configured.
+        pub fn isDefault(self: LevelColorConfig) bool {
+            return self.usesDefaultTheme() and
+                self.trace_color == null and
+                self.debug_color == null and
+                self.info_color == null and
+                self.notice_color == null and
+                self.success_color == null and
+                self.warning_color == null and
+                self.error_color == null and
+                self.fail_color == null and
+                self.critical_color == null and
+                self.fatal_color == null;
         }
     };
 
@@ -627,6 +657,10 @@ pub const Config = struct {
         partial_end_chars: u8 = Constants.RedactionDefaults.partial_end_chars,
         /// Mask character for redacted content.
         mask_char: u8 = Constants.RedactionDefaults.mask_char,
+        /// Max characters to keep when using truncate redaction.
+        truncate_length: usize = Constants.RedactionDefaults.truncate_length,
+        /// Suffix appended when values are truncated.
+        truncate_suffix: []const u8 = Constants.RedactionDefaults.truncate_suffix,
         /// Enable case-insensitive field matching.
         case_insensitive: bool = true,
         /// Log when redaction is applied (for audit).
@@ -782,6 +816,82 @@ pub const Config = struct {
         keep_alive_ms: u64 = 60000,
         /// Enable thread affinity (pin threads to CPUs).
         thread_affinity: bool = false,
+
+        /// Returns a thread-pool configuration optimized for general use.
+        pub fn default() ThreadPoolConfig {
+            return .{};
+        }
+
+        /// Returns a thread-pool configuration for sustained logging throughput.
+        pub fn highThroughput() ThreadPoolConfig {
+            return .{
+                .enabled = true,
+                .thread_count = Constants.ThreadDefaults.thread_count,
+                .queue_size = Constants.ThreadDefaults.max_tasks,
+                .stack_size = 2 * Constants.ThreadDefaults.stack_size,
+                .work_stealing = true,
+            };
+        }
+
+        /// Returns a thread-pool configuration for disk and network-heavy logging.
+        pub fn ioBound() ThreadPoolConfig {
+            return .{
+                .enabled = true,
+                .thread_count = Constants.ThreadDefaults.ioBoundThreadCount(),
+                .queue_size = Constants.ThreadDefaults.queue_size * 2,
+                .work_stealing = true,
+            };
+        }
+
+        /// Returns a thread-pool configuration for CPU-heavy formatting/compression.
+        pub fn cpuBound() ThreadPoolConfig {
+            return .{
+                .enabled = true,
+                .thread_count = Constants.ThreadDefaults.cpuBoundThreadCount(),
+                .queue_size = Constants.ThreadDefaults.queue_size,
+                .work_stealing = false,
+            };
+        }
+
+        /// Returns a small thread-pool configuration for constrained targets.
+        pub fn lowResource() ThreadPoolConfig {
+            return .{
+                .enabled = true,
+                .thread_count = 2,
+                .queue_size = Constants.ThreadDefaults.queue_size_low,
+                .stack_size = Constants.ThreadDefaults.stack_size / 2,
+                .work_stealing = false,
+            };
+        }
+
+        /// Returns a copy with the worker count changed.
+        pub fn withThreadCount(self: ThreadPoolConfig, count: usize) ThreadPoolConfig {
+            var cfg = self;
+            cfg.thread_count = count;
+            cfg.enabled = true;
+            return cfg;
+        }
+
+        /// Returns a copy with queue size changed.
+        pub fn withQueueSize(self: ThreadPoolConfig, size: usize) ThreadPoolConfig {
+            var cfg = self;
+            cfg.queue_size = size;
+            return cfg;
+        }
+
+        /// Returns a copy with per-worker arenas enabled or disabled.
+        pub fn withArena(self: ThreadPoolConfig, enabled: bool) ThreadPoolConfig {
+            var cfg = self;
+            cfg.enable_arena = enabled;
+            return cfg;
+        }
+
+        /// Alias for `withThreadCount`.
+        pub const threads = withThreadCount;
+        /// Alias for `withQueueSize`.
+        pub const queue = withQueueSize;
+        /// Alias for `withArena`.
+        pub const arena = ThreadPoolConfig.withArena;
     };
 
     /// Parallel sink writing configuration.
@@ -885,6 +995,49 @@ pub const Config = struct {
         min_age_days_for_compression: u64 = 1,
         /// Maximum concurrent compression tasks.
         max_concurrent_compressions: usize = 2,
+
+        /// Returns scheduler settings for routine log maintenance.
+        pub fn maintenance(logs_path: []const u8) SchedulerConfig {
+            return .{
+                .enabled = true,
+                .file_pattern = "*.log",
+                .archive_root_dir = logs_path,
+                .compress_before_cleanup = true,
+                .clean_empty_dirs = true,
+            };
+        }
+
+        /// Returns a copy configured for cleanup after `days`.
+        pub fn withCleanupDays(self: SchedulerConfig, days: u64) SchedulerConfig {
+            var cfg = self;
+            cfg.enabled = true;
+            cfg.cleanup_max_age_days = days;
+            return cfg;
+        }
+
+        /// Returns a copy configured to keep at most `count` files.
+        pub fn withMaxFiles(self: SchedulerConfig, count: usize) SchedulerConfig {
+            var cfg = self;
+            cfg.enabled = true;
+            cfg.max_files = count;
+            return cfg;
+        }
+
+        /// Returns a copy with scheduled compression enabled.
+        pub fn withCompression(self: SchedulerConfig, algorithm: CompressionConfig.CompressionAlgorithm) SchedulerConfig {
+            var cfg = self;
+            cfg.enabled = true;
+            cfg.compress_before_cleanup = true;
+            cfg.compression_algorithm = algorithm;
+            return cfg;
+        }
+
+        /// Alias for `withCleanupDays`.
+        pub const cleanupDays = withCleanupDays;
+        /// Alias for `withMaxFiles`.
+        pub const retainFiles = withMaxFiles;
+        /// Alias for `withCompression`.
+        pub const compressBeforeCleanup = SchedulerConfig.withCompression;
     };
 
     /// Metrics collection configuration.
@@ -915,6 +1068,18 @@ pub const Config = struct {
         histogram_buckets: u8 = 10,
         /// Retain metrics history (in snapshots).
         history_size: u16 = 0,
+        /// Prefix/namespace used by exported metric names.
+        metric_prefix: []const u8 = Constants.MetricsConstants.default_prefix,
+        /// Separator used when joining metric prefix and metric name.
+        metric_separator: []const u8 = Constants.MetricsConstants.prometheus_separator,
+        /// Separator used by StatsD exports.
+        statsd_separator: []const u8 = Constants.MetricsConstants.statsd_separator,
+        /// Sanitize exported metric names for the target exporter.
+        sanitize_names: bool = Constants.MetricsConstants.sanitize_names,
+        /// Include per-level counters in metrics exports.
+        export_level_breakdown: bool = Constants.MetricsConstants.include_level_breakdown,
+        /// Include per-sink counters in metrics exports.
+        export_sink_breakdown: bool = Constants.MetricsConstants.include_sink_breakdown,
 
         pub const ExportFormat = enum {
             text,
@@ -974,6 +1139,75 @@ pub const Config = struct {
                 .history_size = 60,
             };
         }
+
+        /// Returns a copy configured for a specific export format.
+        pub fn withExport(self: MetricsConfig, format: ExportFormat) MetricsConfig {
+            var cfg = self;
+            cfg.enabled = true;
+            cfg.export_format = format;
+            return cfg;
+        }
+
+        /// Returns a copy configured for Prometheus export naming.
+        pub fn prometheus(self: MetricsConfig) MetricsConfig {
+            var cfg = self.withExport(.prometheus);
+            cfg.metric_separator = Constants.MetricsConstants.prometheus_separator;
+            cfg.sanitize_names = true;
+            return cfg;
+        }
+
+        /// Returns a copy configured for StatsD export naming.
+        pub fn statsd(self: MetricsConfig) MetricsConfig {
+            var cfg = self.withExport(.statsd);
+            cfg.metric_separator = cfg.statsd_separator;
+            cfg.sanitize_names = false;
+            return cfg;
+        }
+
+        /// Returns a copy with an exported metric prefix/namespace.
+        pub fn withPrefix(self: MetricsConfig, metric_prefix_value: []const u8) MetricsConfig {
+            var cfg = self;
+            cfg.metric_prefix = metric_prefix_value;
+            return cfg;
+        }
+
+        /// Returns a copy with latency histograms enabled.
+        pub fn withLatencyHistogram(self: MetricsConfig, buckets: u8) MetricsConfig {
+            var cfg = self;
+            cfg.enabled = true;
+            cfg.track_latency = true;
+            cfg.enable_histogram = true;
+            cfg.histogram_buckets = buckets;
+            return cfg;
+        }
+
+        /// Returns a copy with error/drop alert thresholds.
+        pub fn withAlerts(self: MetricsConfig, error_rate: f32, drop_rate: f32) MetricsConfig {
+            var cfg = self;
+            cfg.enabled = true;
+            cfg.error_rate_threshold = error_rate;
+            cfg.drop_rate_threshold = drop_rate;
+            return cfg;
+        }
+
+        /// Returns a copy with level/sink export breakdowns enabled or disabled.
+        pub fn withBreakdowns(self: MetricsConfig, levels: bool, sinks: bool) MetricsConfig {
+            var cfg = self;
+            cfg.export_level_breakdown = levels;
+            cfg.export_sink_breakdown = sinks;
+            return cfg;
+        }
+
+        /// Alias for `withExport`.
+        pub const exportAs = withExport;
+        /// Alias for `withPrefix`.
+        pub const prefix = withPrefix;
+        /// Alias for `withLatencyHistogram`.
+        pub const histogram = withLatencyHistogram;
+        /// Alias for `withAlerts`.
+        pub const alerts = withAlerts;
+        /// Alias for `withBreakdowns`.
+        pub const breakdowns = withBreakdowns;
     };
 
     /// Compression configuration.
@@ -1672,6 +1906,55 @@ pub const Config = struct {
             /// Custom format string (requires naming_format to be set)
             custom,
         };
+
+        /// Returns a size-based rotation configuration.
+        pub fn bySize(size_bytes: u64, retention: usize) RotationConfig {
+            return .{
+                .enabled = true,
+                .size_limit = size_bytes,
+                .retention_count = retention,
+            };
+        }
+
+        /// Returns a time-based rotation configuration.
+        pub fn byInterval(interval_name: []const u8, retention: usize) RotationConfig {
+            return .{
+                .enabled = true,
+                .interval = interval_name,
+                .retention_count = retention,
+            };
+        }
+
+        /// Returns a daily rotation configuration.
+        pub fn daily(retention_days: usize) RotationConfig {
+            return byInterval("daily", retention_days);
+        }
+
+        /// Returns a copy with compression enabled for rotated files.
+        pub fn withCompression(self: RotationConfig, algorithm: CompressionConfig.CompressionAlgorithm) RotationConfig {
+            var cfg = self;
+            cfg.enabled = true;
+            cfg.compression_algorithm = algorithm;
+            cfg.compress_on_retention = true;
+            return cfg;
+        }
+
+        /// Returns a copy with archive directory controls configured.
+        pub fn withArchive(self: RotationConfig, dir: []const u8, date_subdirs: bool) RotationConfig {
+            var cfg = self;
+            cfg.enabled = true;
+            cfg.archive_dir = dir;
+            cfg.archive_root_dir = dir;
+            cfg.create_date_subdirs = date_subdirs;
+            return cfg;
+        }
+
+        /// Alias for `bySize`.
+        pub const size = bySize;
+        /// Alias for `byInterval`.
+        pub const intervalRotation = byInterval;
+        /// Alias for `withArchive`.
+        pub const archiveTo = withArchive;
     };
 
     /// Customizable symbols for rule message categories.
@@ -1843,12 +2126,94 @@ pub const Config = struct {
         background_worker: bool = true,
         /// Use arena allocator for batch processing (reduces malloc overhead).
         use_arena: bool = false,
+        /// Queue utilization ratio that records a backpressure event.
+        backpressure_threshold: f64 = Constants.AsyncConstants.backpressure_threshold_ratio,
+        /// Default timeout for explicit drain waits.
+        drain_timeout_ms: u64 = Constants.AsyncConstants.drain_timeout_ms,
 
         pub const OverflowPolicy = enum {
             drop_oldest,
             drop_newest,
             block,
         };
+
+        /// Returns async settings for high-throughput buffered logging.
+        pub fn highThroughput() AsyncConfig {
+            return .{
+                .enabled = true,
+                .buffer_size = Constants.AsyncPresetDefaults.high_throughput_buffer_size,
+                .batch_size = Constants.AsyncPresetDefaults.high_throughput_batch_size,
+                .flush_interval_ms = Constants.AsyncPresetDefaults.high_throughput_flush_interval_ms,
+                .min_flush_interval_ms = Constants.AsyncPresetDefaults.high_throughput_min_flush_interval_ms,
+                .max_latency_ms = Constants.AsyncPresetDefaults.high_throughput_max_latency_ms,
+                .overflow_policy = .drop_oldest,
+                .background_worker = true,
+            };
+        }
+
+        /// Returns async settings for low-latency logging.
+        pub fn lowLatency() AsyncConfig {
+            return .{
+                .enabled = true,
+                .buffer_size = Constants.AsyncPresetDefaults.low_latency_buffer_size,
+                .batch_size = Constants.AsyncPresetDefaults.low_latency_batch_size,
+                .flush_interval_ms = Constants.AsyncPresetDefaults.low_latency_flush_interval_ms,
+                .min_flush_interval_ms = Constants.AsyncPresetDefaults.low_latency_min_flush_interval_ms,
+                .max_latency_ms = Constants.AsyncPresetDefaults.low_latency_max_latency_ms,
+                .overflow_policy = .block,
+                .background_worker = true,
+            };
+        }
+
+        /// Returns async settings that prefer blocking over dropping records.
+        pub fn reliable() AsyncConfig {
+            return .{
+                .enabled = true,
+                .flush_interval_ms = Constants.AsyncPresetDefaults.balanced_flush_interval_ms,
+                .min_flush_interval_ms = Constants.AsyncPresetDefaults.balanced_min_flush_interval_ms,
+                .max_latency_ms = Constants.AsyncPresetDefaults.balanced_max_latency_ms,
+                .overflow_policy = .block,
+                .background_worker = true,
+            };
+        }
+
+        /// Returns a copy with a specific queue size.
+        pub fn withBufferSize(self: AsyncConfig, size: usize) AsyncConfig {
+            var cfg = self;
+            cfg.enabled = true;
+            cfg.buffer_size = size;
+            return cfg;
+        }
+
+        /// Returns a copy with a specific batch size.
+        pub fn withBatchSize(self: AsyncConfig, size: usize) AsyncConfig {
+            var cfg = self;
+            cfg.batch_size = size;
+            return cfg;
+        }
+
+        /// Returns a copy with a specific overflow policy.
+        pub fn withOverflowPolicy(self: AsyncConfig, policy: OverflowPolicy) AsyncConfig {
+            var cfg = self;
+            cfg.overflow_policy = policy;
+            return cfg;
+        }
+
+        /// Returns a copy with a clamped backpressure threshold.
+        pub fn withBackpressureThreshold(self: AsyncConfig, threshold: f64) AsyncConfig {
+            var cfg = self;
+            cfg.backpressure_threshold = if (threshold < 0.0) 0.0 else if (threshold > 1.0) 1.0 else threshold;
+            return cfg;
+        }
+
+        /// Alias for `withBufferSize`.
+        pub const buffer = withBufferSize;
+        /// Alias for `withBatchSize`.
+        pub const batch = withBatchSize;
+        /// Alias for `withOverflowPolicy`.
+        pub const overflow = withOverflowPolicy;
+        /// Alias for `withBackpressureThreshold`.
+        pub const backpressure = withBackpressureThreshold;
     };
 
     /// Returns the default configuration.
@@ -2032,6 +2397,62 @@ pub const Config = struct {
         result.async_config.enabled = true;
         return result;
     }
+
+    /// Returns a copy with metrics configuration applied and top-level metrics enabled.
+    ///
+    /// Use this to keep `enable_metrics` synchronized with the detailed
+    /// `metrics` block when composing production profiles.
+    pub fn withMetrics(self: Config, config: MetricsConfig) Config {
+        var result = self;
+        result.metrics = config;
+        result.enable_metrics = config.enabled;
+        return result;
+    }
+
+    /// Returns a copy with rules configuration applied.
+    pub fn withRules(self: Config, config: RulesConfig) Config {
+        var result = self;
+        result.rules = config;
+        return result;
+    }
+
+    /// Returns a copy with rotation configuration applied.
+    pub fn withRotation(self: Config, config: RotationConfig) Config {
+        var result = self;
+        result.rotation = config;
+        return result;
+    }
+
+    /// Returns a copy with a complete high-throughput async pipeline enabled.
+    pub fn withHighThroughputPipeline(self: Config) Config {
+        var result = self;
+        result.async_config = AsyncConfig.highThroughput();
+        result.thread_pool = ThreadPoolConfig.highThroughput();
+        result.metrics = MetricsConfig.production().withLatencyHistogram(20).prometheus();
+        result.enable_metrics = true;
+        return result;
+    }
+
+    /// Returns a copy with metrics, rules, and maintenance controls enabled.
+    pub fn withObservability(self: Config, metric_prefix: []const u8) Config {
+        var result = self;
+        result.metrics = MetricsConfig.detailed().prometheus().withPrefix(metric_prefix);
+        result.enable_metrics = true;
+        result.rules = RulesConfig.production();
+        result.scheduler.enabled = true;
+        return result;
+    }
+
+    /// Alias for `withMetrics`.
+    pub const metricsConfig = withMetrics;
+    /// Alias for `withRules`.
+    pub const rulesConfig = withRules;
+    /// Alias for `withRotation`.
+    pub const rotationConfig = withRotation;
+    /// Alias for `withHighThroughputPipeline`.
+    pub const pipeline = withHighThroughputPipeline;
+    /// Alias for `withObservability`.
+    pub const observability = withObservability;
 
     /// Returns a configuration with compression enabled.
     ///
@@ -2445,6 +2866,58 @@ test "config arena allocation aliases" {
     try std.testing.expect(arena_via_short_alias.use_arena_allocator);
 }
 
+test "config pipeline builders enable related features" {
+    const cfg = Config.default()
+        .withHighThroughputPipeline()
+        .withObservability("svc.api")
+        .withRotation(Config.RotationConfig.daily(7).withCompression(.zstd));
+
+    try std.testing.expect(cfg.async_config.enabled);
+    try std.testing.expect(cfg.thread_pool.enabled);
+    try std.testing.expect(cfg.enable_metrics);
+    try std.testing.expect(cfg.metrics.enabled);
+    try std.testing.expectEqual(Config.MetricsConfig.ExportFormat.prometheus, cfg.metrics.export_format);
+    try std.testing.expectEqualStrings("svc.api", cfg.metrics.metric_prefix);
+    try std.testing.expect(cfg.rules.enabled);
+    try std.testing.expect(cfg.scheduler.enabled);
+    try std.testing.expect(cfg.rotation.enabled);
+    try std.testing.expectEqual(Config.CompressionConfig.CompressionAlgorithm.zstd, cfg.rotation.compression_algorithm);
+}
+
+test "config async metrics and threadpool helper aliases" {
+    const async_cfg = Config.AsyncConfig.lowLatency()
+        .buffer(128)
+        .batch(8)
+        .overflow(.drop_newest)
+        .backpressure(2.0);
+    try std.testing.expect(async_cfg.enabled);
+    try std.testing.expectEqual(@as(usize, 128), async_cfg.buffer_size);
+    try std.testing.expectEqual(@as(usize, 8), async_cfg.batch_size);
+    try std.testing.expectEqual(Config.AsyncConfig.OverflowPolicy.drop_newest, async_cfg.overflow_policy);
+    try std.testing.expectEqual(@as(f64, 1.0), async_cfg.backpressure_threshold);
+
+    const metrics_cfg = Config.MetricsConfig.minimal()
+        .prometheus()
+        .prefix("worker")
+        .histogram(12)
+        .alerts(0.1, 0.2)
+        .breakdowns(false, true);
+    try std.testing.expect(metrics_cfg.enabled);
+    try std.testing.expectEqual(Config.MetricsConfig.ExportFormat.prometheus, metrics_cfg.export_format);
+    try std.testing.expectEqualStrings("worker", metrics_cfg.metric_prefix);
+    try std.testing.expect(metrics_cfg.track_latency);
+    try std.testing.expect(metrics_cfg.enable_histogram);
+    try std.testing.expectEqual(@as(u8, 12), metrics_cfg.histogram_buckets);
+    try std.testing.expect(!metrics_cfg.export_level_breakdown);
+    try std.testing.expect(metrics_cfg.export_sink_breakdown);
+
+    const pool_cfg = Config.ThreadPoolConfig.ioBound().threads(4).queue(256).arena(true);
+    try std.testing.expect(pool_cfg.enabled);
+    try std.testing.expectEqual(@as(usize, 4), pool_cfg.thread_count);
+    try std.testing.expectEqual(@as(usize, 256), pool_cfg.queue_size);
+    try std.testing.expect(pool_cfg.enable_arena);
+}
+
 test "rules config default values" {
     const rules_config = Config.RulesConfig{};
     try std.testing.expect(!rules_config.enabled);
@@ -2849,6 +3322,23 @@ test "level color config none theme" {
     try std.testing.expectEqualStrings("", cfg_none.getColorForLevel(.err));
 }
 
+test "telemetry metric export helpers" {
+    const base = TelemetryConfig.development();
+
+    const json_cfg = base.withJsonMetrics("metrics.jsonl");
+    try std.testing.expectEqual(TelemetryConfig.MetricFormat.json, json_cfg.metric_format);
+    try std.testing.expectEqualStrings("metrics.jsonl", json_cfg.metrics_file_path.?);
+
+    const prom_cfg = base.withPrometheusMetrics("metrics.prom").withMetricPrefix("api");
+    try std.testing.expectEqual(TelemetryConfig.MetricFormat.prometheus, prom_cfg.metric_format);
+    try std.testing.expectEqualStrings("metrics.prom", prom_cfg.metrics_file_path.?);
+    try std.testing.expectEqualStrings("api", prom_cfg.metric_prefix);
+    try std.testing.expect(prom_cfg.sanitize_metric_names);
+
+    const raw_cfg = prom_cfg.withMetricNameSanitization(false);
+    try std.testing.expect(!raw_cfg.sanitize_metric_names);
+}
+
 /// OpenTelemetry telemetry configuration options.
 pub const TelemetryConfig = struct {
     /// Enable OpenTelemetry integration.
@@ -2874,6 +3364,9 @@ pub const TelemetryConfig = struct {
 
     /// File path for file-based exporter (JSONL format).
     exporter_file_path: ?[]const u8 = null,
+
+    /// File path for metrics export when using JSON/Prometheus formats.
+    metrics_file_path: ?[]const u8 = null,
 
     /// Batch span export size.
     batch_size: usize = Constants.TelemetryDefaults.batch_size,
@@ -2904,6 +3397,15 @@ pub const TelemetryConfig = struct {
 
     /// Metric exporter format.
     metric_format: MetricFormat = .otlp,
+
+    /// Optional prefix applied to exported metric names.
+    metric_prefix: []const u8 = Constants.TelemetryDefaults.metric_prefix,
+
+    /// Separator inserted between `metric_prefix` and the original metric name.
+    metric_prefix_separator: []const u8 = Constants.TelemetryDefaults.metric_prefix_separator,
+
+    /// Sanitize metric names for exporter compatibility.
+    sanitize_metric_names: bool = Constants.TelemetryDefaults.sanitize_metric_names,
 
     /// Compress span exports.
     compress_exports: bool = false,
@@ -3147,4 +3649,46 @@ pub const TelemetryConfig = struct {
             .sampling_strategy = .always_on,
         };
     }
+
+    /// Returns a copy with a metric export format and path configured.
+    pub fn withMetricExport(self: TelemetryConfig, format: MetricFormat, path: []const u8) TelemetryConfig {
+        var cfg = self;
+        cfg.metric_format = format;
+        cfg.metrics_file_path = path;
+        return cfg;
+    }
+
+    /// Returns a copy configured for JSON metrics at the given path.
+    pub fn withJsonMetrics(self: TelemetryConfig, path: []const u8) TelemetryConfig {
+        return self.withMetricExport(.json, path);
+    }
+
+    /// Returns a copy configured for Prometheus metrics at the given path.
+    pub fn withPrometheusMetrics(self: TelemetryConfig, path: []const u8) TelemetryConfig {
+        return self.withMetricExport(.prometheus, path);
+    }
+
+    /// Returns a copy that prefixes exported metric names.
+    pub fn withMetricPrefix(self: TelemetryConfig, prefix: []const u8) TelemetryConfig {
+        var cfg = self;
+        cfg.metric_prefix = prefix;
+        return cfg;
+    }
+
+    /// Returns a copy that controls metric name sanitization.
+    pub fn withMetricNameSanitization(self: TelemetryConfig, enabled: bool) TelemetryConfig {
+        var cfg = self;
+        cfg.sanitize_metric_names = enabled;
+        return cfg;
+    }
+
+    /// Alias for `withMetricPrefix`.
+    pub const metricPrefix = withMetricPrefix;
+    pub const prefixedMetrics = withMetricPrefix;
+
+    /// Alias for `withPrometheusMetrics`.
+    pub const prometheusMetrics = withPrometheusMetrics;
+
+    /// Alias for `withJsonMetrics`.
+    pub const jsonMetrics = withJsonMetrics;
 };

--- a/src/constants.zig
+++ b/src/constants.zig
@@ -175,6 +175,10 @@ pub const AsyncConstants = struct {
     pub const block_sleep_ns: u64 = 1 * TimeConstants.ns_per_ms;
     /// Default batch size for async processing.
     pub const batch_size: usize = BufferSizes.async_batch;
+    /// Queue utilization ratio that counts as backpressure.
+    pub const backpressure_threshold_ratio: f64 = 0.9;
+    /// Default time to wait for an async queue to drain during explicit waits.
+    pub const drain_timeout_ms: u64 = 5000;
 };
 
 /// Default limits for queues and buffers.
@@ -271,6 +275,12 @@ pub const TelemetryDefaults = struct {
     pub const trace_header: []const u8 = "traceparent";
     /// Default baggage/correlation context header name.
     pub const baggage_header: []const u8 = "baggage";
+    /// Default prefix for exported metric names.
+    pub const metric_prefix: []const u8 = "";
+    /// Default separator inserted between a metric prefix and metric name.
+    pub const metric_prefix_separator: []const u8 = "_";
+    /// Whether metric names should be sanitized for exporter compatibility.
+    pub const sanitize_metric_names: bool = true;
 };
 
 /// Async preset tuning defaults.
@@ -326,6 +336,20 @@ test "telemetry defaults exist" {
     try std.testing.expectEqual(@as(usize, TelemetryDefaults.header_initial_capacity), @as(usize, 256));
     try std.testing.expectEqualStrings(TelemetryDefaults.trace_header, "traceparent");
     try std.testing.expectEqualStrings(TelemetryDefaults.baggage_header, "baggage");
+    try std.testing.expectEqualStrings(TelemetryDefaults.metric_prefix, "");
+    try std.testing.expectEqualStrings(TelemetryDefaults.metric_prefix_separator, "_");
+    try std.testing.expect(TelemetryDefaults.sanitize_metric_names);
+}
+
+test "shared metrics and async defaults exist" {
+    try std.testing.expectEqualStrings("logly", MetricsConstants.default_prefix);
+    try std.testing.expectEqualStrings("_", MetricsConstants.prometheus_separator);
+    try std.testing.expectEqualStrings(".", MetricsConstants.statsd_separator);
+    try std.testing.expect(MetricsConstants.sanitize_names);
+    try std.testing.expect(MetricsConstants.include_level_breakdown);
+    try std.testing.expect(MetricsConstants.include_sink_breakdown);
+    try std.testing.expect(AsyncConstants.backpressure_threshold_ratio > 0.0);
+    try std.testing.expect(AsyncConstants.drain_timeout_ms > 0);
 }
 
 /// Log level count and priorities.
@@ -423,6 +447,19 @@ pub const TimeConstants = struct {
 
 /// Metrics-related constants.
 pub const MetricsConstants = struct {
+    /// Default exported metric namespace.
+    pub const default_prefix: []const u8 = "logly";
+    /// Separator used by Prometheus-compatible metric names.
+    pub const prometheus_separator: []const u8 = "_";
+    /// Separator used by StatsD metric names.
+    pub const statsd_separator: []const u8 = ".";
+    /// Sanitize metric names by default for exporter compatibility.
+    pub const sanitize_names: bool = true;
+    /// Include per-level counters in metrics exports by default.
+    pub const include_level_breakdown: bool = true;
+    /// Include per-sink counters in metrics exports by default.
+    pub const include_sink_breakdown: bool = true;
+
     /// Default histogram bucket boundaries in nanoseconds.
     pub const histogram_boundaries = [_]u64{
         1_000,         2_000,                5_000,     10_000,     20_000,     50_000,     100_000,     200_000,     500_000,
@@ -1084,6 +1121,10 @@ pub const RedactionDefaults = struct {
     pub const partial_end_chars: u8 = 4;
     /// Default mask character.
     pub const mask_char: u8 = '*';
+    /// Default max length for truncate redaction.
+    pub const truncate_length: u8 = 8;
+    /// Default suffix for truncate redaction.
+    pub const truncate_suffix: []const u8 = "...";
 };
 
 /// Rate limiting defaults.

--- a/src/filter.zig
+++ b/src/filter.zig
@@ -234,6 +234,19 @@ pub const Filter = struct {
 
     pub const create = init;
 
+    /// Sets the logical mode used when combining filter rules.
+    pub fn setMode(self: *Filter, mode: Mode) void {
+        self.mode = mode;
+    }
+
+    /// Returns true when the filter is currently using the requested mode.
+    pub fn isMode(self: *const Filter, mode: Mode) bool {
+        return self.mode == mode;
+    }
+
+    /// Alias for setMode.
+    pub const withMode = setMode;
+
     /// Releases all resources associated with the filter.
     ///
     /// Frees all rules and character patterns.
@@ -973,4 +986,14 @@ test "filter with custom level" {
 
     // info (20) < warning (30), should not pass
     try std.testing.expect(!filter.shouldLog(&record_custom_low));
+}
+
+test "filter mode helpers" {
+    var filter = Filter.init(std.testing.allocator);
+    defer filter.deinit();
+
+    try std.testing.expect(filter.isMode(.all));
+    filter.setMode(.any);
+    try std.testing.expect(filter.isMode(.any));
+    try std.testing.expect(!filter.isMode(.none));
 }

--- a/src/formatter.zig
+++ b/src/formatter.zig
@@ -662,6 +662,49 @@ pub const Formatter = struct {
         return buf.toOwnedSlice();
     }
 
+    /// Returns the number of interpolation placeholders in a custom format template.
+    ///
+    /// Supported placeholders are balanced `{name}` tokens. Escaped braces `{{` and `}}`
+    /// are treated as literal braces.
+    pub fn countTemplatePlaceholders(template: []const u8) !usize {
+        var count: usize = 0;
+        var i: usize = 0;
+
+        while (i < template.len) {
+            switch (template[i]) {
+                '{' => {
+                    if (i + 1 < template.len and template[i + 1] == '{') {
+                        i += 2;
+                        continue;
+                    }
+
+                    const end = std.mem.indexOfScalarPos(u8, template, i + 1, '}') orelse return error.UnbalancedBraces;
+                    if (end == i + 1) return error.InvalidTemplate;
+                    count += 1;
+                    i = end + 1;
+                },
+                '}' => {
+                    if (i + 1 < template.len and template[i + 1] == '}') {
+                        i += 2;
+                        continue;
+                    }
+                    return error.UnbalancedBraces;
+                },
+                else => i += 1,
+            }
+        }
+
+        return count;
+    }
+
+    /// Validates that a custom format template only uses balanced placeholder braces.
+    ///
+    /// This is a lightweight syntax check for custom formatter strings and does not
+    /// allocate or change the formatter state.
+    pub fn validateTemplate(template: []const u8) !void {
+        _ = try countTemplatePlaceholders(template);
+    }
+
     /// Formats a log record directly to a writer.
     ///
     /// This avoids intermediate allocations when writing directly to a sink.
@@ -683,23 +726,31 @@ pub const Formatter = struct {
         // Use custom color if available (highest priority)
         var color_code: []const u8 = if (record.custom_level_color) |c| c else "";
 
-        // If no custom color from record, check config.level_colors (overrides & themes)
+        // If no custom color from record, check explicit config overrides first.
         if (color_code.len == 0) {
             if (@hasField(@TypeOf(config), "level_colors")) {
-                color_code = config.level_colors.getColorForLevel(record.level);
+                if (config.level_colors.getOverrideForLevel(record.level)) |override| {
+                    color_code = override;
+                } else if (!config.level_colors.usesDefaultTheme()) {
+                    color_code = config.level_colors.getColorForLevel(record.level);
+                }
             }
         }
 
-        // If still no color, check legacy theme on formatter
+        // If still no color, check the formatter/sink theme.
         if (color_code.len == 0) {
             if (self.theme) |t| {
                 color_code = t.getColor(record.level);
             }
         }
 
-        // Fallback to default
+        // Fallback to default config/level colors.
         if (color_code.len == 0) {
-            color_code = record.level.defaultColor();
+            if (@hasField(@TypeOf(config), "level_colors")) {
+                color_code = config.level_colors.getColorForLevel(record.level);
+            } else {
+                color_code = record.level.defaultColor();
+            }
         }
 
         // Check for custom log format
@@ -1678,6 +1729,14 @@ test "formatter timestamp helper formats numeric and textual values" {
     try std.testing.expect(std.mem.indexOf(u8, textual, "default") == null);
 }
 
+test "formatter template validation" {
+    try std.testing.expectEqual(@as(usize, 3), try Formatter.countTemplatePlaceholders("{time} [{level}] {message}"));
+    try std.testing.expectEqual(@as(usize, 1), try Formatter.countTemplatePlaceholders("prefix {{literal}} {message}"));
+    try Formatter.validateTemplate("{time} - {message}");
+    try std.testing.expectError(error.UnbalancedBraces, Formatter.validateTemplate("{time"));
+    try std.testing.expectError(error.InvalidTemplate, Formatter.validateTemplate("{}"));
+}
+
 test "formatter plain text" {
     const allocator = std.testing.allocator;
     var formatter = Formatter.init(allocator);
@@ -1697,6 +1756,54 @@ test "formatter plain text" {
     try std.testing.expect(std.mem.indexOf(u8, output_str, "INFO") != null);
     try std.testing.expect(std.mem.indexOf(u8, output_str, "test_mod") != null);
     try std.testing.expect(std.mem.indexOf(u8, output_str, "Test message") != null);
+}
+
+test "formatter sink theme applies when config colors are default" {
+    const allocator = std.testing.allocator;
+    var formatter = Formatter.init(allocator);
+    defer formatter.deinit();
+    formatter.setTheme(Formatter.Theme.neon());
+
+    var record = Record.init(allocator, .info, "Themed message");
+    defer record.deinit();
+    record.timestamp = 1700000000000;
+
+    var config = Config{};
+    config.color = true;
+    config.global_color_display = true;
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    defer buf.deinit();
+
+    try formatter.formatToWriter(&buf.writer, &record, config);
+    const output_str = buf.written();
+
+    try std.testing.expect(std.mem.indexOf(u8, output_str, "\x1b[38;5;255m") != null);
+}
+
+test "formatter explicit level color overrides sink theme" {
+    const allocator = std.testing.allocator;
+    var formatter = Formatter.init(allocator);
+    defer formatter.deinit();
+    formatter.setTheme(Formatter.Theme.neon());
+
+    var record = Record.init(allocator, .info, "Override message");
+    defer record.deinit();
+    record.timestamp = 1700000000000;
+
+    var config = Config{};
+    config.color = true;
+    config.global_color_display = true;
+    config.level_colors.info_color = "35";
+
+    var buf = std.Io.Writer.Allocating.init(allocator);
+    defer buf.deinit();
+
+    try formatter.formatToWriter(&buf.writer, &record, config);
+    const output_str = buf.written();
+
+    try std.testing.expect(std.mem.indexOf(u8, output_str, "\x1b[35m") != null);
+    try std.testing.expect(std.mem.indexOf(u8, output_str, "\x1b[38;5;255m") == null);
 }
 
 test "formatter json" {

--- a/src/metrics.zig
+++ b/src/metrics.zig
@@ -698,6 +698,47 @@ pub const Metrics = struct {
         });
     }
 
+    fn writePrometheusMetricName(self: *const Metrics, writer: anytype, name: []const u8) !void {
+        try Utils.writeTelemetryMetricName(
+            writer,
+            self.config.metric_prefix,
+            self.config.metric_separator,
+            name,
+            self.config.sanitize_names,
+        );
+    }
+
+    fn writeStatsdMetricName(self: *const Metrics, writer: anytype, name: []const u8) !void {
+        try Utils.writeTelemetryMetricName(
+            writer,
+            self.config.metric_prefix,
+            self.config.statsd_separator,
+            name,
+            self.config.sanitize_names,
+        );
+    }
+
+    fn writePrometheusHeader(self: *const Metrics, writer: anytype, name: []const u8, help: []const u8, metric_type: []const u8) !void {
+        try writer.writeAll("# HELP ");
+        try self.writePrometheusMetricName(writer, name);
+        try writer.writeByte(' ');
+        try writer.writeAll(help);
+        try writer.writeByte('\n');
+        try writer.writeAll("# TYPE ");
+        try self.writePrometheusMetricName(writer, name);
+        try writer.writeByte(' ');
+        try writer.writeAll(metric_type);
+        try writer.writeByte('\n');
+    }
+
+    fn writePrometheusUnsigned(self: *const Metrics, writer: anytype, name: []const u8, help: []const u8, metric_type: []const u8, value: u64) !void {
+        try self.writePrometheusHeader(writer, name, help, metric_type);
+        try self.writePrometheusMetricName(writer, name);
+        try writer.writeByte(' ');
+        try Utils.writeInt(writer, value);
+        try writer.writeByte('\n');
+    }
+
     /// Export as Prometheus format.
     pub fn exportPrometheus(self: *Metrics, allocator: std.mem.Allocator) ![]u8 {
         const snapshot = self.getSnapshot();
@@ -706,35 +747,49 @@ pub const Metrics = struct {
         var list_writer = Utils.ArrayListWriter.init(&buf, allocator);
         const writer = &list_writer.writer;
 
-        try writer.writeAll("# HELP logly_records_total Total log records\n");
-        try writer.writeAll("# TYPE logly_records_total counter\n");
-        try writer.writeAll("logly_records_total ");
-        try Utils.writeInt(writer, snapshot.total_records);
-        try writer.writeByte('\n');
+        try self.writePrometheusUnsigned(writer, "records_total", "Total log records", "counter", snapshot.total_records);
+        try self.writePrometheusUnsigned(writer, "bytes_total", "Total bytes logged", "counter", snapshot.total_bytes);
+        try self.writePrometheusUnsigned(writer, "dropped_total", "Dropped records", "counter", snapshot.dropped_records);
+        try self.writePrometheusUnsigned(writer, "errors_total", "Error count", "counter", snapshot.error_count);
 
-        try writer.writeAll("# HELP logly_bytes_total Total bytes logged\n");
-        try writer.writeAll("# TYPE logly_bytes_total counter\n");
-        try writer.writeAll("logly_bytes_total ");
-        try Utils.writeInt(writer, snapshot.total_bytes);
-        try writer.writeByte('\n');
-
-        try writer.writeAll("# HELP logly_dropped_total Dropped records\n");
-        try writer.writeAll("# TYPE logly_dropped_total counter\n");
-        try writer.writeAll("logly_dropped_total ");
-        try Utils.writeInt(writer, snapshot.dropped_records);
-        try writer.writeByte('\n');
-
-        try writer.writeAll("# HELP logly_errors_total Error count\n");
-        try writer.writeAll("# TYPE logly_errors_total counter\n");
-        try writer.writeAll("logly_errors_total ");
-        try Utils.writeInt(writer, snapshot.error_count);
-        try writer.writeByte('\n');
-
-        try writer.writeAll("# HELP logly_records_per_second Records per second\n");
-        try writer.writeAll("# TYPE logly_records_per_second gauge\n");
-        try writer.writeAll("logly_records_per_second ");
+        try self.writePrometheusHeader(writer, "records_per_second", "Records per second", "gauge");
+        try self.writePrometheusMetricName(writer, "records_per_second");
+        try writer.writeByte(' ');
         try writer.print("{d:.2}", .{snapshot.records_per_second});
         try writer.writeByte('\n');
+
+        if (self.config.export_level_breakdown) {
+            try self.writePrometheusHeader(writer, "level_records_total", "Log records by level", "counter");
+            for (snapshot.level_counts, 0..) |count, i| {
+                if (count == 0) continue;
+                try self.writePrometheusMetricName(writer, "level_records_total");
+                try writer.writeAll("{level=");
+                try Utils.writePrometheusLabelValue(writer, indexToLevelName(i));
+                try writer.writeAll("} ");
+                try Utils.writeInt(writer, count);
+                try writer.writeByte('\n');
+            }
+        }
+
+        if (self.config.export_sink_breakdown) {
+            try self.writePrometheusHeader(writer, "sink_records_total", "Log records by sink", "counter");
+            try self.writePrometheusHeader(writer, "sink_errors_total", "Sink write errors", "counter");
+            for (self.sink_metrics.items) |metric| {
+                try self.writePrometheusMetricName(writer, "sink_records_total");
+                try writer.writeAll("{sink=");
+                try Utils.writePrometheusLabelValue(writer, metric.name);
+                try writer.writeAll("} ");
+                try Utils.writeInt(writer, metric.getRecordsWritten());
+                try writer.writeByte('\n');
+
+                try self.writePrometheusMetricName(writer, "sink_errors_total");
+                try writer.writeAll("{sink=");
+                try Utils.writePrometheusLabelValue(writer, metric.name);
+                try writer.writeAll("} ");
+                try Utils.writeInt(writer, metric.getWriteErrors());
+                try writer.writeByte('\n');
+            }
+        }
 
         return buf.toOwnedSlice(allocator);
     }
@@ -742,19 +797,23 @@ pub const Metrics = struct {
     /// Export as StatsD format.
     pub fn exportStatsd(self: *Metrics, allocator: std.mem.Allocator) ![]u8 {
         const snapshot = self.getSnapshot();
-        return try std.fmt.allocPrint(allocator,
-            \\logly.records.total:{d}|c
-            \\logly.bytes.total:{d}|c
-            \\logly.dropped.total:{d}|c
-            \\logly.errors.total:{d}|c
-            \\logly.rps:{d:.2}|g
-        , .{
-            snapshot.total_records,
-            snapshot.total_bytes,
-            snapshot.dropped_records,
-            snapshot.error_count,
-            snapshot.records_per_second,
-        });
+        var buf: std.ArrayList(u8) = .empty;
+        errdefer buf.deinit(allocator);
+        var list_writer = Utils.ArrayListWriter.init(&buf, allocator);
+        const writer = &list_writer.writer;
+
+        try self.writeStatsdMetricName(writer, "records.total");
+        try writer.print(":{d}|c\n", .{snapshot.total_records});
+        try self.writeStatsdMetricName(writer, "bytes.total");
+        try writer.print(":{d}|c\n", .{snapshot.total_bytes});
+        try self.writeStatsdMetricName(writer, "dropped.total");
+        try writer.print(":{d}|c\n", .{snapshot.dropped_records});
+        try self.writeStatsdMetricName(writer, "errors.total");
+        try writer.print(":{d}|c\n", .{snapshot.error_count});
+        try self.writeStatsdMetricName(writer, "rps");
+        try writer.print(":{d:.2}|g\n", .{snapshot.records_per_second});
+
+        return buf.toOwnedSlice(allocator);
     }
 
     /// Get average latency in nanoseconds.
@@ -1025,6 +1084,15 @@ pub const Metrics = struct {
         const idx = levelToIndex(level);
         return @as(u64, self.level_counts[idx].load(.monotonic));
     }
+
+    /// Resets the counter for a single log level without affecting other metrics.
+    pub fn resetLevelMetrics(self: *Metrics, level: Level) void {
+        const idx = levelToIndex(level);
+        self.level_counts[idx].store(@as(Constants.AtomicUnsigned, 0), .monotonic);
+    }
+
+    /// Alias for resetLevelMetrics.
+    pub const clearLevelMetrics = resetLevelMetrics;
 
     /// Returns the number of sinks being tracked.
     pub fn sinkCount(self: *const Metrics) usize {
@@ -1321,6 +1389,22 @@ test "metrics level count" {
     try std.testing.expectEqual(@as(u64, 1), metrics.levelCount(.err));
 }
 
+test "metrics reset level count" {
+    var metrics = Metrics.init(std.testing.allocator);
+    defer metrics.deinit();
+
+    metrics.recordLog(.info, 50);
+    metrics.recordLog(.err, 100);
+
+    try std.testing.expectEqual(@as(u64, 1), metrics.levelCount(.info));
+    try std.testing.expectEqual(@as(u64, 1), metrics.levelCount(.err));
+
+    metrics.resetLevelMetrics(.info);
+
+    try std.testing.expectEqual(@as(u64, 0), metrics.levelCount(.info));
+    try std.testing.expectEqual(@as(u64, 1), metrics.levelCount(.err));
+}
+
 test "metrics reset" {
     var metrics = Metrics.init(std.testing.allocator);
     defer metrics.deinit();
@@ -1425,4 +1509,34 @@ test "metrics sink totals and last record age" {
 
     try std.testing.expectEqual(@as(u64, 2), metrics.totalSinkErrors());
     try std.testing.expectEqual(@as(u64, 3), metrics.totalSinkFlushes());
+}
+
+test "metrics prometheus export uses configured names and breakdowns" {
+    var metrics = Metrics.initWithConfig(std.testing.allocator, Config.MetricsConfig.production().prometheus().withPrefix("svc.api"));
+    defer metrics.deinit();
+
+    metrics.recordLog(.info, 100);
+    metrics.recordLog(.err, 50);
+    const sink_idx = try metrics.addSink("file\"main");
+    metrics.recordSinkWrite(sink_idx, 150);
+    metrics.recordSinkError(sink_idx);
+
+    const exported = try metrics.exportPrometheus(std.testing.allocator);
+    defer std.testing.allocator.free(exported);
+
+    try std.testing.expect(std.mem.indexOf(u8, exported, "svc_api_records_total 2") != null);
+    try std.testing.expect(std.mem.indexOf(u8, exported, "svc_api_level_records_total{level=\"INFO\"} 1") != null);
+    try std.testing.expect(std.mem.indexOf(u8, exported, "svc_api_sink_errors_total{sink=\"file\\\"main\"} 1") != null);
+}
+
+test "metrics statsd export supports configured prefix" {
+    var metrics = Metrics.initWithConfig(std.testing.allocator, Config.MetricsConfig.production().statsd().withPrefix("svc.api"));
+    defer metrics.deinit();
+
+    metrics.recordLog(.warning, 25);
+
+    const exported = try metrics.exportStatsd(std.testing.allocator);
+    defer std.testing.allocator.free(exported);
+
+    try std.testing.expect(std.mem.indexOf(u8, exported, "svc.api.records.total:1|c") != null);
 }

--- a/src/network.zig
+++ b/src/network.zig
@@ -244,9 +244,49 @@ pub fn sendUdp(socket: std.Io.net.Socket, address: std.Io.net.IpAddress, data: [
     _ = stats.messages_sent.fetchAdd(1, .monotonic);
 }
 
+/// Sends data via a TCP stream.
+pub fn sendTcp(stream: std.Io.net.Stream, data: []const u8) !void {
+    var buffer: [Constants.BufferSizes.message]u8 = undefined;
+    var writer = stream.writer(Utils.io(), &buffer);
+    writer.interface.writeAll(data) catch {
+        _ = stats.errors.fetchAdd(1, .monotonic);
+        return NetworkError.SendFailed;
+    };
+    writer.interface.flush() catch {
+        _ = stats.errors.fetchAdd(1, .monotonic);
+        return NetworkError.SendFailed;
+    };
+    _ = stats.bytes_sent.fetchAdd(@truncate(data.len), .monotonic);
+    _ = stats.messages_sent.fetchAdd(1, .monotonic);
+}
+
+/// Formats a syslog message and sends it via UDP.
+pub fn sendSyslogUdp(
+    allocator: std.mem.Allocator,
+    socket: std.Io.net.Socket,
+    address: std.Io.net.IpAddress,
+    facility: SyslogFacility,
+    severity: SyslogSeverity,
+    hostname: []const u8,
+    app_name: []const u8,
+    message: []const u8,
+) !void {
+    const formatted = try formatSyslog(allocator, facility, severity, hostname, app_name, message);
+    defer allocator.free(formatted);
+    try sendUdp(socket, address, formatted);
+}
+
 /// Alias for sendUdp
 pub const udpSend = sendUdp;
 pub const sendToUdp = sendUdp;
+
+/// Alias for sendTcp
+pub const tcpSend = sendTcp;
+pub const sendToTcp = sendTcp;
+
+/// Alias for sendSyslogUdp
+pub const syslogSend = sendSyslogUdp;
+pub const sendSyslog = sendSyslogUdp;
 
 /// Fetches a JSON response from a URL.
 /// Returns the parsed JSON value (caller must deinit).
@@ -307,6 +347,8 @@ pub const LogServer = struct {
     running: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
     tcp_thread: ?std.Thread = null,
     udp_thread: ?std.Thread = null,
+    tcp_port: u16 = 0,
+    udp_port: u16 = 0,
     messages_received: std.atomic.Value(Constants.AtomicUnsigned) = std.atomic.Value(Constants.AtomicUnsigned).init(0),
 
     pub fn init(allocator: std.mem.Allocator) LogServer {
@@ -327,10 +369,14 @@ pub const LogServer = struct {
 
     pub fn stop(self: *LogServer) void {
         self.running.store(false, .monotonic);
+        self.wakeTcpWorker();
+        self.wakeUdpWorker();
         if (self.tcp_thread) |t| t.join();
         if (self.udp_thread) |t| t.join();
         self.tcp_thread = null;
         self.udp_thread = null;
+        self.tcp_port = 0;
+        self.udp_port = 0;
     }
 
     /// Alias for stop
@@ -354,6 +400,7 @@ pub const LogServer = struct {
 
     pub fn startTcp(self: *LogServer, port: u16, callback: *const fn ([]const u8) void) !void {
         self.running.store(true, .monotonic);
+        self.tcp_port = port;
         self.tcp_thread = try std.Thread.spawn(.{}, tcpWorker, .{ self, port, callback });
     }
 
@@ -362,11 +409,28 @@ pub const LogServer = struct {
 
     pub fn startUdp(self: *LogServer, port: u16, callback: *const fn ([]const u8) void) !void {
         self.running.store(true, .monotonic);
+        self.udp_port = port;
         self.udp_thread = try std.Thread.spawn(.{}, udpWorker, .{ self, port, callback });
     }
 
     /// Alias for startUdp
     pub const listenUdp = startUdp;
+
+    fn wakeTcpWorker(self: *LogServer) void {
+        if (self.tcp_thread == null or self.tcp_port == 0) return;
+        const host_name = std.Io.net.HostName.init("127.0.0.1") catch return;
+        const stream = host_name.connect(Utils.io(), self.tcp_port, .{ .mode = .stream, .protocol = .tcp }) catch return;
+        stream.close(Utils.io());
+    }
+
+    fn wakeUdpWorker(self: *LogServer) void {
+        if (self.udp_thread == null or self.udp_port == 0) return;
+        const address = std.Io.net.IpAddress.parse("127.0.0.1", self.udp_port) catch return;
+        const local_address = std.Io.net.IpAddress.parse("0.0.0.0", 0) catch return;
+        const socket = local_address.bind(Utils.io(), .{ .mode = .dgram, .protocol = .udp }) catch return;
+        defer socket.close(Utils.io());
+        socket.send(Utils.io(), &address, "") catch {};
+    }
 
     fn tcpWorker(self: *LogServer, port: u16, callback: *const fn ([]const u8) void) void {
         const io = Utils.io();
@@ -476,4 +540,62 @@ test "syslog formatting" {
     // user(1)*8 + info(6) = 14
     try std.testing.expect(std.mem.startsWith(u8, formatted, "<14>1 "));
     try std.testing.expect(std.mem.indexOf(u8, formatted, "localhost test-app - - - Hello Syslog") != null);
+}
+
+test "network send helpers" {
+    const allocator = std.testing.allocator;
+
+    const TestContext = struct {
+        var received: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+
+        fn onMessage(message: []const u8) void {
+            _ = message;
+            received.store(true, .monotonic);
+        }
+    };
+
+    resetStats();
+
+    const udp = try createUdpSocket(allocator, "udp://127.0.0.1:5514");
+    defer udp.socket.close(Utils.io());
+
+    try sendSyslogUdp(allocator, udp.socket, udp.address, .user, .info, "localhost", "logly", "syslog test");
+
+    const udp_stats = getStats();
+    try std.testing.expect(udp_stats.totalMessagesCount() >= 1);
+
+    TestContext.received.store(false, .monotonic);
+    var server = LogServer.init(allocator);
+    defer server.deinit();
+
+    const port: u16 = 39090;
+    try server.startTcp(port, TestContext.onMessage);
+    defer server.stop();
+
+    var stream: ?std.Io.net.Stream = null;
+    var attempt: u8 = 0;
+    while (attempt < 10 and stream == null) : (attempt += 1) {
+        stream = connectTcp(allocator, "tcp://127.0.0.1:39090") catch {
+            Utils.io().sleep(.fromMilliseconds(10), .awake) catch {};
+            continue;
+        };
+    }
+
+    try std.testing.expect(stream != null);
+    defer if (stream) |s| s.close(Utils.io());
+
+    resetStats();
+    try sendTcp(stream.?, "tcp test");
+    if (stream) |s| {
+        s.close(Utils.io());
+        stream = null;
+    }
+    var wait_attempt: u8 = 0;
+    while (wait_attempt < 50 and !TestContext.received.load(.monotonic)) : (wait_attempt += 1) {
+        Utils.io().sleep(.fromMilliseconds(10), .awake) catch {};
+    }
+
+    const tcp_stats = getStats();
+    try std.testing.expect(tcp_stats.totalMessagesCount() >= 1);
+    try std.testing.expect(TestContext.received.load(.monotonic));
 }

--- a/src/redactor.zig
+++ b/src/redactor.zig
@@ -246,6 +246,7 @@ pub const Redactor = struct {
         partial_end,
         hash,
         mask_middle,
+        truncate,
 
         pub fn apply(self: RedactionType, allocator: std.mem.Allocator, value: []const u8) ![]u8 {
             return switch (self) {
@@ -271,14 +272,9 @@ pub const Redactor = struct {
                 .hash => blk: {
                     var hash: [32]u8 = undefined;
                     std.crypto.hash.sha2.Sha256.hash(value, &hash, .{});
-                    const hex_val = std.fmt.bytesToHex(hash[0..8], .lower);
-                    const prefix = "[HASH:";
-                    const suffix = "]";
-                    const res = try allocator.alloc(u8, prefix.len + hex_val.len + suffix.len);
-                    @memcpy(res[0..prefix.len], prefix);
-                    @memcpy(res[prefix.len..][0..hex_val.len], &hex_val);
-                    @memcpy(res[prefix.len + hex_val.len ..], suffix);
-                    break :blk res;
+                    const hex_val = try Utils.bytesToHexLowerAlloc(allocator, hash[0..8]);
+                    defer allocator.free(hex_val);
+                    break :blk try std.fmt.allocPrint(allocator, "[HASH:{s}]", .{hex_val});
                 },
                 .mask_middle => blk: {
                     if (value.len <= 6) {
@@ -288,6 +284,17 @@ pub const Redactor = struct {
                     @memcpy(result[0..3], value[0..3]);
                     @memset(result[3 .. value.len - 3], '*');
                     @memcpy(result[value.len - 3 ..], value[value.len - 3 ..]);
+                    break :blk result;
+                },
+                .truncate => blk: {
+                    const max_len: usize = Constants.RedactionDefaults.truncate_length;
+                    const suffix = Constants.RedactionDefaults.truncate_suffix;
+                    if (value.len <= max_len) {
+                        break :blk try allocator.dupe(u8, value);
+                    }
+                    const result = try allocator.alloc(u8, max_len + suffix.len);
+                    @memcpy(result[0..max_len], value[0..max_len]);
+                    @memcpy(result[max_len..], suffix);
                     break :blk result;
                 },
             };
@@ -321,6 +328,27 @@ pub const Redactor = struct {
         }
 
         return redactor;
+    }
+
+    /// Applies field/pattern rules defined in the redaction config.
+    ///
+    /// This does not mutate existing rules; it only adds new ones from config.
+    pub fn applyConfigRules(self: *Redactor) !void {
+        if (self.config.fields) |fields| {
+            const mapped = mapConfigRedactionType(self.config.default_type);
+            for (fields) |field_name| {
+                try self.addField(field_name, mapped);
+            }
+        }
+
+        if (self.config.patterns) |patterns| {
+            const pattern_type: RedactionPattern.PatternType = if (self.config.enable_regex) .regex else .contains;
+            for (patterns, 0..) |pattern, i| {
+                const name = try std.fmt.allocPrint(self.allocator, "config_pattern_{d}", .{i});
+                defer self.allocator.free(name);
+                try self.addPattern(name, pattern_type, pattern, self.config.replacement);
+            }
+        }
     }
 
     /// Releases all resources associated with the redactor.
@@ -632,8 +660,53 @@ pub const Redactor = struct {
             .full => try self.allocator.dupe(u8, self.config.replacement),
             .partial_start => Utils.maskString(self.allocator, value, mask_char, start_chars, end_chars, .partial_start),
             .partial_end => Utils.maskString(self.allocator, value, mask_char, start_chars, end_chars, .partial_end),
-            .hash => Utils.computeRedactionHash(self.allocator, value),
+            .hash => self.computeRedactionHash(value),
             .mask_middle => Utils.maskString(self.allocator, value, mask_char, start_chars, end_chars, .mask_middle),
+            .truncate => self.applyTruncate(value),
+        };
+    }
+
+    fn applyTruncate(self: *Redactor, value: []const u8) ![]u8 {
+        const max_len = self.config.truncate_length;
+        const suffix = self.config.truncate_suffix;
+        if (max_len == 0) return self.allocator.dupe(u8, suffix);
+        if (value.len <= max_len) return self.allocator.dupe(u8, value);
+        const result = try self.allocator.alloc(u8, max_len + suffix.len);
+        @memcpy(result[0..max_len], value[0..max_len]);
+        @memcpy(result[max_len..], suffix);
+        return result;
+    }
+
+    fn computeRedactionHash(self: *Redactor, value: []const u8) ![]u8 {
+        return switch (self.config.hash_algorithm) {
+            .sha256 => Utils.computeRedactionHash(self.allocator, value),
+            .sha512 => blk: {
+                var hash: [64]u8 = undefined;
+                std.crypto.hash.sha2.Sha512.hash(value, &hash, .{});
+                break :blk formatHashTag(self.allocator, hash[0..8]);
+            },
+            .md5 => blk: {
+                var hash: [16]u8 = undefined;
+                std.crypto.hash.Md5.hash(value, &hash, .{});
+                break :blk formatHashTag(self.allocator, hash[0..8]);
+            },
+        };
+    }
+
+    fn formatHashTag(allocator: std.mem.Allocator, hash_bytes: []const u8) ![]u8 {
+        const hex_val = try Utils.bytesToHexLowerAlloc(allocator, hash_bytes);
+        defer allocator.free(hex_val);
+        return std.fmt.allocPrint(allocator, "[HASH:{s}]", .{hex_val});
+    }
+
+    fn mapConfigRedactionType(rtype: RedactionConfig.RedactionType) RedactionType {
+        return switch (rtype) {
+            .full => .full,
+            .partial_start => .partial_start,
+            .partial_end => .partial_end,
+            .hash => .hash,
+            .mask_middle => .mask_middle,
+            .truncate => .truncate,
         };
     }
 
@@ -836,6 +909,10 @@ pub const Redactor = struct {
 
     /// Alias for initWithConfig
     pub const createWithConfig = initWithConfig;
+
+    /// Alias for applyConfigRules
+    pub const applyConfig = applyConfigRules;
+    pub const loadConfigRules = applyConfigRules;
 
     /// Alias for setCallback
     // pub const callback = setCallback; // shadows parameters
@@ -1123,4 +1200,31 @@ test "redactor preview message does not mutate stats" {
     defer std.testing.allocator.free(actual);
     try std.testing.expect(std.mem.indexOf(u8, actual, "[REDACTED]") != null);
     try std.testing.expect(redactor.getStats().getTotalProcessed() > after_processed);
+}
+
+test "redactor truncate redaction" {
+    var redactor = Redactor.init(std.testing.allocator);
+    defer redactor.deinit();
+
+    redactor.config.truncate_length = 4;
+    redactor.config.truncate_suffix = "...";
+    try redactor.addField("token", .truncate);
+
+    const redacted = try redactor.redactField("token", "abcdef");
+    defer std.testing.allocator.free(redacted);
+
+    try std.testing.expectEqualStrings("abcd...", redacted);
+}
+
+test "redactor hash algorithm selection" {
+    var redactor = Redactor.init(std.testing.allocator);
+    defer redactor.deinit();
+
+    redactor.config.hash_algorithm = .md5;
+    try redactor.addField("secret", .hash);
+
+    const redacted = try redactor.redactField("secret", "super-secret");
+    defer std.testing.allocator.free(redacted);
+
+    try std.testing.expect(std.mem.startsWith(u8, redacted, "[HASH:"));
 }

--- a/src/rotation.zig
+++ b/src/rotation.zig
@@ -159,6 +159,11 @@ pub const Rotation = struct {
             return Utils.atomicLoadU64(&self.compression_errors);
         }
 
+        /// Returns last rotation timestamp in milliseconds.
+        pub fn getLastRotationTimeMs(self: *const RotationStats) u64 {
+            return Utils.atomicLoadU64(&self.last_rotation_time_ms);
+        }
+
         /// Checks if any rotation errors occurred.
         pub fn hasErrors(self: *const RotationStats) bool {
             return self.rotation_errors.load(.monotonic) > 0;
@@ -208,6 +213,9 @@ pub const Rotation = struct {
         /// Alias for getCompressionErrors
         pub const compressionErrors = getCompressionErrors;
         pub const compressErrors = getCompressionErrors;
+
+        /// Alias for getLastRotationTimeMs
+        pub const lastRotationTimeMs = getLastRotationTimeMs;
 
         /// Alias for hasErrors
         pub const hasRotationErrors = hasErrors;
@@ -488,6 +496,19 @@ pub const Rotation = struct {
         return if (remaining > 0) remaining else 0;
     }
 
+    /// Returns the next rotation time as epoch seconds.
+    ///
+    /// Returns null when interval rotation is disabled.
+    pub fn nextRotationAt(self: *const Rotation) ?i64 {
+        const remaining = self.nextRotationInSeconds() orelse return null;
+        return Utils.currentSeconds() + remaining;
+    }
+
+    /// Returns how many seconds have elapsed since the last rotation.
+    pub fn rotationAgeSeconds(self: *const Rotation) i64 {
+        return Utils.currentSeconds() - self.last_rotation;
+    }
+
     /// Forces immediate rotation regardless of current interval/size checks.
     pub fn forceRotate(self: *Rotation, file_ptr: *std.Io.File) !void {
         self.mutex.lockUncancelable(Utils.io());
@@ -596,6 +617,12 @@ pub const Rotation = struct {
 
     /// Alias for nextRotationInSeconds
     pub const secondsUntilNextRotation = nextRotationInSeconds;
+
+    /// Alias for nextRotationAt
+    pub const nextRotationAtSeconds = nextRotationAt;
+
+    /// Alias for rotationAgeSeconds
+    pub const lastRotationAgeSeconds = rotationAgeSeconds;
 
     /// Alias for forceRotate
     pub const rotateNow = forceRotate;
@@ -1508,4 +1535,19 @@ test "rotation next rotation in seconds" {
     try std.testing.expect(remaining != null);
     try std.testing.expect(remaining.? >= 0);
     try std.testing.expect(remaining.? <= @as(i64, Constants.TimeConstants.seconds_per_hour));
+}
+
+test "rotation next rotation at and age helpers" {
+    const allocator = std.testing.allocator;
+
+    var rot = try Rotation.init(allocator, "test-next-at.log", "hourly", null, 7);
+    defer rot.deinit();
+
+    rot.last_rotation = Utils.currentSeconds() - 10;
+    const next_at = rot.nextRotationAt();
+    try std.testing.expect(next_at != null);
+    try std.testing.expect(next_at.? >= Utils.currentSeconds());
+
+    const age = rot.rotationAgeSeconds();
+    try std.testing.expect(age >= 0);
 }

--- a/src/rules.zig
+++ b/src/rules.zig
@@ -846,6 +846,19 @@ pub const Rules = struct {
         return disabled_total;
     }
 
+    /// Returns the total number of configured rules.
+    pub fn totalRuleCount(self: *Rules) usize {
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
+
+        return self.rules.items.len;
+    }
+
+    /// Returns true when at least one rule is configured.
+    pub fn hasRules(self: *Rules) bool {
+        return self.totalRuleCount() > 0;
+    }
+
     /// Returns true if at least one rule would match this record.
     /// This does not mutate once-only rule state.
     pub fn wouldMatchAny(self: *Rules, record: *const Record) bool {
@@ -1690,6 +1703,26 @@ test "rules statistics" {
     const stats = rules.getStats();
     try std.testing.expect(stats.rules_evaluated.load(.monotonic) > 0);
     try std.testing.expect(stats.rules_matched.load(.monotonic) > 0);
+}
+
+test "rules count helpers" {
+    var rules = Rules.init(std.testing.allocator);
+    defer rules.deinit();
+
+    try std.testing.expect(!rules.hasRules());
+
+    const messages = [_]Rules.RuleMessage{
+        .{ .category = .general_information, .message = "count helper" },
+    };
+
+    try rules.add(.{
+        .id = 11,
+        .level_match = .{ .any = {} },
+        .messages = &messages,
+    });
+
+    try std.testing.expectEqual(@as(usize, 1), rules.totalRuleCount());
+    try std.testing.expect(rules.hasRules());
 }
 
 test "rules json format" {

--- a/src/sampler.zig
+++ b/src/sampler.zig
@@ -369,6 +369,55 @@ pub const Sampler = struct {
         );
         self.mutex.unlock(Utils.io());
 
+        return self.applyDecision(sample_decision, rate_exceeded_info, adjustment_info);
+    }
+
+    /// Determines whether a record should be sampled using a deterministic key.
+    ///
+    /// Useful when you want consistent sampling for the same ID (user/session/etc.).
+    pub fn shouldSampleKey(self: *Sampler, key: []const u8) bool {
+        return self.shouldSampleKeyWithReason(key).accepted;
+    }
+
+    /// Determines whether a record should be sampled using a deterministic key,
+    /// returning the structured decision payload.
+    pub fn shouldSampleKeyWithReason(self: *Sampler, key: []const u8) SampleDecision {
+        return switch (self.strategy) {
+            .none => blk: {
+                _ = self.state.stats.total_records_sampled.fetchAdd(1, .monotonic);
+                break :blk self.applyDecision(.{ .accepted = true, .sample_rate = 1.0 }, null, null);
+            },
+            .probability => |prob| blk: {
+                _ = self.state.stats.total_records_sampled.fetchAdd(1, .monotonic);
+                const effective = clampRate(prob);
+                const roll = hashToUnitInterval(key);
+                if (roll < effective) {
+                    break :blk self.applyDecision(.{ .accepted = true, .sample_rate = effective }, null, null);
+                }
+                break :blk self.applyDecision(.{ .accepted = false, .sample_rate = effective, .reject_reason = .probability_filter }, null, null);
+            },
+            .every_n => |n| blk: {
+                _ = self.state.stats.total_records_sampled.fetchAdd(1, .monotonic);
+                if (n == 0) {
+                    break :blk self.applyDecision(.{ .accepted = true, .sample_rate = 1.0 }, null, null);
+                }
+                const effective = 1.0 / @as(f64, @floatFromInt(n));
+                const key_decision = if (@mod(hashToU64(key), @as(u64, n)) == 0)
+                    SampleDecision{ .accepted = true, .sample_rate = effective }
+                else
+                    SampleDecision{ .accepted = false, .sample_rate = effective, .reject_reason = .every_n_filter };
+                break :blk self.applyDecision(key_decision, null, null);
+            },
+            .rate_limit, .adaptive => self.shouldSampleWithReason(),
+        };
+    }
+
+    fn applyDecision(
+        self: *Sampler,
+        sample_decision: SampleDecision,
+        rate_exceeded_info: ?RateExceededInfo,
+        adjustment_info: ?AdjustmentInfo,
+    ) SampleDecision {
         if (adjustment_info) |info| {
             if (self.on_rate_adjustment) |cb| cb(info.old, info.new, "throughput adjustment");
         }
@@ -386,6 +435,16 @@ pub const Sampler = struct {
         }
 
         return sample_decision;
+    }
+
+    fn hashToU64(key: []const u8) u64 {
+        return std.hash.Wyhash.hash(0, key);
+    }
+
+    fn hashToUnitInterval(key: []const u8) f64 {
+        const hash = hashToU64(key);
+        const denom: f64 = @floatFromInt(std.math.maxInt(u64));
+        return @as(f64, @floatFromInt(hash)) / denom;
     }
 
     fn resetStateForStrategy(self: *Sampler) void {
@@ -450,6 +509,13 @@ pub const Sampler = struct {
         self.mutex.lockUncancelable(Utils.io());
         self.state.current_rate = bounded_max;
         self.mutex.unlock(Utils.io());
+    }
+
+    /// Reseeds the internal RNG for probability-based sampling.
+    pub fn setSeed(self: *Sampler, seed: u64) void {
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
+        self.state.rng = std.Random.DefaultPrng.init(seed);
     }
 
     /// Disables filtering and allows all records through.
@@ -595,6 +661,10 @@ pub const Sampler = struct {
     pub const sampleWithReason = shouldSampleWithReason;
     pub const decision = shouldSampleWithReason;
 
+    /// Alias for shouldSampleKey
+    pub const sampleKey = shouldSampleKey;
+    pub const keyDecision = shouldSampleKeyWithReason;
+
     /// Alias for getCurrentRate
     pub const rate = getCurrentRate;
 
@@ -614,6 +684,9 @@ pub const Sampler = struct {
 
     /// Alias for setAdaptive
     pub const adaptive = setAdaptive;
+
+    /// Alias for setSeed
+    pub const reseed = setSeed;
 
     /// Alias for disableSampling
     pub const disable = disableSampling;
@@ -808,6 +881,15 @@ test "sampler adaptive" {
 
     const rate = sampler.getCurrentRate();
     try std.testing.expect(rate < 1.0);
+}
+
+test "sampler key-based deterministic sampling" {
+    var sampler = Sampler.init(std.testing.allocator, .{ .probability = 0.5 });
+    defer sampler.deinit();
+
+    const first = sampler.shouldSampleKey("user-123");
+    const second = sampler.shouldSampleKey("user-123");
+    try std.testing.expectEqual(first, second);
 }
 
 test "sampler decision details include reason" {

--- a/src/scheduler.zig
+++ b/src/scheduler.zig
@@ -657,6 +657,42 @@ pub const Scheduler = struct {
     /// Alias for setTaskDependency
     pub const dependsOn = setTaskDependency;
 
+    /// Validates that every task dependency resolves and that no dependency cycle exists.
+    ///
+    /// Returns an error if a dependency name cannot be resolved or if following the
+    /// dependency chain revisits a task.
+    pub fn validateDependencies(self: *Scheduler) !void {
+        self.mutex.lockUncancelable(Utils.io());
+        defer self.mutex.unlock(Utils.io());
+
+        for (self.tasks.items, 0..) |task, start_index| {
+            _ = task;
+            var current_index: usize = start_index;
+            var hops: usize = 0;
+
+            while (true) {
+                if (hops > self.tasks.items.len) return error.DependencyCycle;
+
+                const current_task = self.tasks.items[current_index];
+                const dep_name = current_task.depends_on orelse break;
+
+                var next_index: ?usize = null;
+                for (self.tasks.items, 0..) |candidate, candidate_index| {
+                    if (std.mem.eql(u8, candidate.name, dep_name)) {
+                        next_index = candidate_index;
+                        break;
+                    }
+                }
+
+                const resolved_index = next_index orelse return error.MissingDependency;
+                if (resolved_index == start_index) return error.DependencyCycle;
+
+                current_index = resolved_index;
+                hops += 1;
+            }
+        }
+    }
+
     /// Adds a cleanup task for old log files.
     ///
     /// Arguments:
@@ -2110,6 +2146,25 @@ test "scheduler name based controls and snapshots" {
     try std.testing.expect(scheduler.removeTaskByName("named-task"));
     try std.testing.expect(!scheduler.hasTaskNamed("named-task"));
     try std.testing.expect(!scheduler.removeTaskByName("named-task"));
+}
+
+test "scheduler dependency validation" {
+    const allocator = std.testing.allocator;
+    const scheduler = try Scheduler.init(allocator);
+    defer scheduler.deinit();
+
+    const Callbacks = struct {
+        fn run(task: *Scheduler.ScheduledTask) anyerror!void {
+            _ = task;
+        }
+    };
+
+    const a = try scheduler.addCustomTask("task-a", .{ .once = 0 }, Callbacks.run);
+    const b = try scheduler.addCustomTask("task-b", .{ .once = 0 }, Callbacks.run);
+    try scheduler.setTaskDependency(a, "task-b");
+    try scheduler.setTaskDependency(b, "task-a");
+
+    try std.testing.expectError(error.DependencyCycle, scheduler.validateDependencies());
 }
 
 var scheduler_tick_called = false;

--- a/src/telemetry.zig
+++ b/src/telemetry.zig
@@ -583,6 +583,7 @@ pub const Telemetry = struct {
         };
 
         if (result) |_| {} else |err| {
+            std.debug.print("ERROR IN EXPORT: {s}\n", .{@errorName(err)});
             if (self.config.on_error) |callback| {
                 callback(@errorName(err));
             }
@@ -613,14 +614,14 @@ pub const Telemetry = struct {
             try Network.sendUdp(self.network_socket.?, self.network_address.?, self.batch_buffer.items);
             self.exporter_stats.recordNetworkExport();
         } else if (self.config.exporter_file_path) |path| {
-            const file = try std.Io.Dir.cwd().createFile(Utils.io(), path, .{ .truncate = false });
+            const file = try std.Io.Dir.cwd().createFile(Utils.io(), path, .{ .read = true, .truncate = false });
             defer file.close(Utils.io());
             var file_buffer: [Constants.BufferSizes.telemetry]u8 = undefined;
             var file_writer = file.writer(Utils.io(), &file_buffer);
             try file_writer.seekTo(try file.length(Utils.io()));
             try file_writer.interface.writeAll(self.batch_buffer.items);
             try file_writer.interface.writeAll("\n");
-            try file_writer.interface.flush();
+            try file_writer.flush();
         }
 
         self.exporter_stats.recordExport(self.completed_spans.items.len, self.batch_buffer.items.len);
@@ -1014,10 +1015,9 @@ pub const Telemetry = struct {
     fn exportToFile(self: *Telemetry) !void {
         const path = self.config.exporter_file_path orelse return;
 
-        const file = try std.Io.Dir.cwd().createFile(Utils.io(), path, .{ .truncate = false });
+        const file = try std.Io.Dir.cwd().createFile(Utils.io(), path, .{ .read = true, .truncate = false });
         defer file.close(Utils.io());
 
-        // Write each span as a JSON line
         var file_buffer: [Constants.BufferSizes.telemetry]u8 = undefined;
         var file_writer = file.writer(Utils.io(), &file_buffer);
         try file_writer.seekTo(try file.length(Utils.io()));
@@ -1029,7 +1029,7 @@ pub const Telemetry = struct {
             try writer.writeByte('\n');
             try file_writer.interface.writeAll(self.batch_buffer.items);
         }
-        try file_writer.interface.flush();
+        try file_writer.flush();
     }
 
     /// Export spans to network (TCP/UDP) using Network module
@@ -1129,12 +1129,29 @@ pub const Telemetry = struct {
         try self.exportSpansInternal();
     }
 
-    /// Exports all metrics (placeholder for actual export logic)
+    /// Exports all metrics using the configured exporter.
     pub fn exportMetrics(self: *Telemetry) !void {
         if (!self.enabled) return;
 
         self.mutex.lockUncancelable(utils.io());
         defer self.mutex.unlock(utils.io());
+
+        if (self.metric_count == 0) return;
+
+        const export_result: anyerror!void = switch (self.config.metric_format) {
+            .json => self.exportMetricsJson(),
+            .prometheus => self.exportMetricsPrometheus(),
+            .otlp => {},
+        };
+
+        if (export_result) |_| {
+            self.exporter_stats.recordMetricExport(self.metric_count);
+        } else |err| {
+            if (self.config.on_error) |callback| {
+                callback(@errorName(err));
+            }
+            self.exporter_stats.recordError();
+        }
 
         // Clear metrics after export
         for (self.metrics.items) |metric| {
@@ -1142,6 +1159,105 @@ pub const Telemetry = struct {
         }
         self.metrics.clearRetainingCapacity();
         self.metric_count = 0;
+    }
+
+    /// Export metrics as JSON lines to the configured metrics path.
+    fn exportMetricsJson(self: *Telemetry) !void {
+        const path = self.config.metrics_file_path orelse self.config.exporter_file_path orelse return;
+
+        const file = try std.Io.Dir.cwd().createFile(Utils.io(), path, .{ .read = true, .truncate = false });
+        defer file.close(Utils.io());
+
+        var file_buffer: [Constants.BufferSizes.telemetry]u8 = undefined;
+        var file_writer = file.writer(Utils.io(), &file_buffer);
+        try file_writer.seekTo(try file.length(Utils.io()));
+
+        for (self.metrics.items) |metric| {
+            self.batch_buffer.clearRetainingCapacity();
+            var batch_writer = Utils.ArrayListWriter.init(&self.batch_buffer, self.allocator);
+            const writer = &batch_writer.writer;
+            try self.writeMetricJson(writer, metric);
+            try writer.writeByte('\n');
+            try file_writer.interface.writeAll(self.batch_buffer.items);
+        }
+        try file_writer.flush();
+    }
+
+    /// Export metrics in Prometheus text format to the configured metrics path.
+    fn exportMetricsPrometheus(self: *Telemetry) !void {
+        const path = self.config.metrics_file_path orelse self.config.exporter_file_path orelse return;
+
+        const file = try std.Io.Dir.cwd().createFile(Utils.io(), path, .{ .read = true, .truncate = false });
+        defer file.close(Utils.io());
+
+        var file_buffer: [Constants.BufferSizes.telemetry]u8 = undefined;
+        var file_writer = file.writer(Utils.io(), &file_buffer);
+        try file_writer.seekTo(try file.length(Utils.io()));
+
+        for (self.metrics.items) |metric| {
+            self.batch_buffer.clearRetainingCapacity();
+            var batch_writer = Utils.ArrayListWriter.init(&self.batch_buffer, self.allocator);
+            const writer = &batch_writer.writer;
+            try self.writeMetricPrometheus(writer, metric);
+            try file_writer.interface.writeAll(self.batch_buffer.items);
+        }
+        try file_writer.flush();
+    }
+
+    /// Write a single metric as a JSON object.
+    fn writeMetricJson(self: *Telemetry, writer: anytype, metric: Metric) !void {
+        try writer.writeAll("{\"name\":\"");
+        try utils.writeTelemetryMetricName(
+            writer,
+            self.config.metric_prefix,
+            self.config.metric_prefix_separator,
+            metric.name,
+            self.config.sanitize_metric_names,
+        );
+        try writer.writeAll("\",\"kind\":\"");
+        try writer.writeAll(@tagName(metric.kind));
+        try writer.writeAll("\",\"value\":");
+        try writer.print("{d}", .{metric.value});
+
+        if (metric.unit) |unit| {
+            try writer.writeAll(",\"unit\":\"");
+            try utils.escapeJsonString(writer, unit);
+            try writer.writeByte('"');
+        }
+
+        if (metric.description) |desc| {
+            try writer.writeAll(",\"description\":\"");
+            try utils.escapeJsonString(writer, desc);
+            try writer.writeByte('"');
+        }
+
+        try writer.writeAll(",\"timestamp\":");
+        try utils.writeInt(writer, utils.safeToUnsigned(u64, metric.timestamp));
+        try writer.writeByte('}');
+    }
+
+    /// Write a single metric in Prometheus text format.
+    fn writeMetricPrometheus(self: *Telemetry, writer: anytype, metric: Metric) !void {
+        try writer.writeAll("# TYPE ");
+        try utils.writeTelemetryMetricName(
+            writer,
+            self.config.metric_prefix,
+            self.config.metric_prefix_separator,
+            metric.name,
+            self.config.sanitize_metric_names,
+        );
+        try writer.writeByte(' ');
+        try writer.writeAll(@tagName(metric.kind));
+        try writer.writeByte('\n');
+        try utils.writeTelemetryMetricName(
+            writer,
+            self.config.metric_prefix,
+            self.config.metric_prefix_separator,
+            metric.name,
+            self.config.sanitize_metric_names,
+        );
+        try writer.writeByte(' ');
+        try writer.print("{d}\n", .{metric.value});
     }
 
     /// Flushes all data (spans and metrics)
@@ -1865,6 +1981,33 @@ test "Span creation and lifecycle" {
     // Check counters updated
     try std.testing.expectEqual(@as(usize, 0), telemetry.active_span_count);
     try std.testing.expectEqual(@as(usize, 1), telemetry.completed_span_count);
+}
+
+test "File exporter writes spans" {
+    const allocator = std.testing.allocator;
+    const path = "telemetry_spans_test.jsonl";
+
+    std.Io.Dir.cwd().deleteFile(Utils.io(), path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(Utils.io(), path) catch {};
+
+    var config = TelemetryConfig.file(path);
+    config.sampling_strategy = .always_on;
+
+    var telemetry = try Telemetry.init(allocator, config);
+    defer telemetry.deinit();
+
+    var span = try telemetry.startSpan("file_export_test", .{});
+    defer span.deinit();
+
+    span.end();
+    try telemetry.endSpan(&span);
+    try telemetry.exportSpans();
+
+    const file = try std.Io.Dir.cwd().openFile(Utils.io(), path, .{});
+    defer file.close(Utils.io());
+
+    const stat = try file.stat(Utils.io());
+    try std.testing.expect(stat.size > 0);
 }
 
 test "Span with parent" {
@@ -2654,6 +2797,67 @@ test "Telemetry metric batch helper" {
     const recorded = try telemetry.recordMetricsBatch(metrics[0..]);
     try std.testing.expectEqual(@as(usize, 3), recorded);
     try std.testing.expectEqual(@as(usize, 3), telemetry.getMetricCount());
+}
+
+test "Telemetry metrics export formats" {
+    const allocator = std.testing.allocator;
+    const json_path = "telemetry-metrics-test.jsonl";
+    const prom_path = "telemetry-metrics-test.prom";
+
+    defer std.Io.Dir.cwd().deleteFile(Utils.io(), json_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(Utils.io(), prom_path) catch {};
+
+    var json_config = TelemetryConfig.development();
+    json_config.metric_format = .json;
+    json_config.metrics_file_path = json_path;
+
+    var telemetry_json = try Telemetry.init(allocator, json_config);
+    defer telemetry_json.deinit();
+
+    try telemetry_json.recordCounter("requests.total", 2.0);
+    try telemetry_json.exportMetrics();
+
+    const json_file = try std.Io.Dir.cwd().openFile(Utils.io(), json_path, .{});
+    defer json_file.close(Utils.io());
+    try std.testing.expect((try json_file.length(Utils.io())) > 0);
+
+    var prom_config = TelemetryConfig.development();
+    prom_config.metric_format = .prometheus;
+    prom_config.metrics_file_path = prom_path;
+
+    var telemetry_prom = try Telemetry.init(allocator, prom_config);
+    defer telemetry_prom.deinit();
+
+    try telemetry_prom.recordGauge("cpu.usage", 12.5);
+    try telemetry_prom.exportMetrics();
+
+    const prom_file = try std.Io.Dir.cwd().openFile(Utils.io(), prom_path, .{});
+    defer prom_file.close(Utils.io());
+    try std.testing.expect((try prom_file.length(Utils.io())) > 0);
+}
+
+test "Telemetry metric export applies prefix and sanitization" {
+    const allocator = std.testing.allocator;
+    const path = "telemetry-metrics-prefixed.prom";
+
+    defer std.Io.Dir.cwd().deleteFile(Utils.io(), path) catch {};
+
+    var config = TelemetryConfig.development()
+        .withPrometheusMetrics(path)
+        .withMetricPrefix("api.v1");
+    config.metric_prefix_separator = ":";
+
+    var telemetry = try Telemetry.init(allocator, config);
+    defer telemetry.deinit();
+
+    try telemetry.recordCounter("requests.total", 5.0);
+    try telemetry.exportMetrics();
+
+    const body = try std.Io.Dir.cwd().readFileAlloc(Utils.io(), path, allocator, .limited(4096));
+    defer allocator.free(body);
+
+    try std.testing.expect(std.mem.indexOf(u8, body, "api_v1:requests_total") != null);
+    try std.testing.expect(std.mem.indexOf(u8, body, "requests.total") == null);
 }
 
 test "Telemetry startSpanFromTraceparent" {

--- a/src/thread_pool.zig
+++ b/src/thread_pool.zig
@@ -772,7 +772,8 @@ pub const ThreadPool = struct {
 
             if (item) |work| {
                 const start_time = Utils.currentNanos();
-                const wait_time = start_time - work.submitted_at;
+                const wait_time_ms = Utils.currentMillis() - work.submitted_at;
+                const wait_time_ns = @as(u64, @intCast(@max(0, wait_time_ms))) * Constants.TimeConstants.ns_per_ms;
 
                 // Get arena allocator if available
                 var task_allocator: ?std.mem.Allocator = null;
@@ -788,7 +789,7 @@ pub const ThreadPool = struct {
                 }
 
                 const exec_time = Utils.currentNanos() - start_time;
-                _ = pool.stats.total_wait_time_ns.fetchAdd(@truncate(@as(u64, @intCast(@max(0, wait_time)))), .monotonic);
+                _ = pool.stats.total_wait_time_ns.fetchAdd(@truncate(wait_time_ns), .monotonic);
                 _ = pool.stats.total_exec_time_ns.fetchAdd(@truncate(@as(u64, @intCast(@max(0, exec_time)))), .monotonic);
                 _ = pool.stats.tasks_completed.fetchAdd(1, .monotonic);
                 _ = worker.tasks_processed.fetchAdd(1, .monotonic);

--- a/src/utils.zig
+++ b/src/utils.zig
@@ -1416,8 +1416,86 @@ pub fn maskString(
 pub fn computeRedactionHash(allocator: std.mem.Allocator, value: []const u8) ![]u8 {
     var hash: [32]u8 = undefined;
     std.crypto.hash.sha2.Sha256.hash(value, &hash, .{});
-    const hex_val = std.fmt.bytesToHex(hash[0..8], .lower);
+    const hex_val = try bytesToHexLowerAlloc(allocator, hash[0..8]);
+    defer allocator.free(hex_val);
     return std.fmt.allocPrint(allocator, "[HASH:{s}]", .{hex_val});
+}
+
+/// Converts bytes to a lowercase hexadecimal string using the provided allocator.
+pub fn bytesToHexLowerAlloc(allocator: std.mem.Allocator, bytes: []const u8) ![]u8 {
+    const hex_chars = "0123456789abcdef";
+    const result = try allocator.alloc(u8, bytes.len * 2);
+    for (bytes, 0..) |b, i| {
+        result[i * 2] = hex_chars[b >> 4];
+        result[i * 2 + 1] = hex_chars[b & 0x0f];
+    }
+    return result;
+}
+
+/// Returns true when a byte is safe in an exported telemetry metric name.
+///
+/// Uses the portable Prometheus/OpenTelemetry subset: ASCII letters, digits,
+/// underscore, and colon. Dots, dashes, spaces, and path separators are not
+/// accepted because they can break Prometheus text output.
+pub fn isTelemetryMetricNameChar(c: u8) bool {
+    return std.ascii.isAlphanumeric(c) or c == '_' or c == ':';
+}
+
+/// Writes a telemetry metric name with optional prefixing and sanitization.
+///
+/// When sanitization is enabled, unsupported bytes are replaced with `_` and
+/// an initial digit is protected by a leading `_`. This lets JSON, Prometheus,
+/// and future OTLP exporters share one consistent name policy.
+pub fn writeTelemetryMetricName(
+    writer: anytype,
+    prefix: []const u8,
+    separator: []const u8,
+    name: []const u8,
+    sanitize: bool,
+) !void {
+    var wrote_any = false;
+    if (prefix.len > 0) {
+        try writeTelemetryMetricNamePart(writer, prefix, sanitize, &wrote_any);
+        if (separator.len > 0 and name.len > 0) {
+            try writeTelemetryMetricNamePart(writer, separator, sanitize, &wrote_any);
+        }
+    }
+    try writeTelemetryMetricNamePart(writer, name, sanitize, &wrote_any);
+}
+
+/// Writes a Prometheus label value with the minimal required escaping.
+///
+/// Escapes backslash, quote, and newline so arbitrary sink names and other
+/// user-provided labels remain valid in text exposition output.
+pub fn writePrometheusLabelValue(writer: anytype, value: []const u8) !void {
+    try writer.writeByte('"');
+    for (value) |c| {
+        switch (c) {
+            '\\' => try writer.writeAll("\\\\"),
+            '"' => try writer.writeAll("\\\""),
+            '\n' => try writer.writeAll("\\n"),
+            else => try writer.writeByte(c),
+        }
+    }
+    try writer.writeByte('"');
+}
+
+fn writeTelemetryMetricNamePart(writer: anytype, part: []const u8, sanitize: bool, wrote_any: *bool) !void {
+    for (part) |c| {
+        if (!sanitize) {
+            try writer.writeByte(c);
+            wrote_any.* = true;
+            continue;
+        }
+
+        if (!wrote_any.* and std.ascii.isDigit(c)) {
+            try writer.writeByte('_');
+            wrote_any.* = true;
+        }
+
+        try writer.writeByte(if (isTelemetryMetricNameChar(c)) c else '_');
+        wrote_any.* = true;
+    }
 }
 
 /// Replaces all occurrences of a substring with a replacement string.
@@ -1499,4 +1577,36 @@ test "durationSinceNs" {
     const duration = durationSinceNs(start);
     // Duration should be very small (microseconds to milliseconds) since we just started
     try std.testing.expect(duration < 1_000_000_000); // Less than 1 second
+}
+
+test "writeTelemetryMetricName sanitizes and prefixes" {
+    var buf = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer buf.deinit();
+
+    try writeTelemetryMetricName(&buf.writer, "api.v1", "_", "http.requests-total", true);
+    try std.testing.expectEqualStrings("api_v1_http_requests_total", buf.written());
+}
+
+test "writeTelemetryMetricName preserves raw names when disabled" {
+    var buf = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer buf.deinit();
+
+    try writeTelemetryMetricName(&buf.writer, "", "_", "99.raw.metric", false);
+    try std.testing.expectEqualStrings("99.raw.metric", buf.written());
+}
+
+test "writeTelemetryMetricName protects leading digits" {
+    var buf = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer buf.deinit();
+
+    try writeTelemetryMetricName(&buf.writer, "", "_", "99.requests", true);
+    try std.testing.expectEqualStrings("_99_requests", buf.written());
+}
+
+test "writePrometheusLabelValue escapes unsafe bytes" {
+    var buf = std.Io.Writer.Allocating.init(std.testing.allocator);
+    defer buf.deinit();
+
+    try writePrometheusLabelValue(&buf.writer, "file\"sink\\main\nnext");
+    try std.testing.expectEqualStrings("\"file\\\"sink\\\\main\\nnext\"", buf.written());
 }

--- a/src/version.zig
+++ b/src/version.zig
@@ -1,4 +1,4 @@
 //! Logly Version Information
 
-/// Logly V0.1.8 | Author: Muhammad Fiaz | License: MIT
-pub const version = "0.1.8";
+/// Logly V0.1.9 | Author: Muhammad Fiaz | License: MIT
+pub const version = "0.1.9";


### PR DESCRIPTION
## [0.1.9]

### Added

- **Redaction truncate support**: new `RedactionType.truncate` with configurable `truncate_length` and `truncate_suffix` in `RedactionConfig`.
- **Redaction hash selection**: configurable hash algorithm (`sha256`, `sha512`, `md5`) for hash-based redaction.
- **Deterministic key sampling**: `Sampler.shouldSampleKey(...)` and `shouldSampleKeyWithReason(...)` for stable sampling decisions.
- **Rotation time helpers**: `Rotation.nextRotationAt()` and `Rotation.rotationAgeSeconds()` with convenience aliases.
- **Telemetry metrics export**: JSON and Prometheus metric exports with `TelemetryConfig.metrics_file_path` override.
- **Telemetry metric naming controls**: `metric_prefix`, `metric_prefix_separator`, and `sanitize_metric_names` with config helpers for exporter-safe metric names.
- **Pipeline configuration builders**: chainable helpers for async, thread pool, metrics, scheduler, rotation, rules, and full high-throughput/observability profiles.
- **Metrics export customization**: configurable metric prefix, Prometheus/StatsD separators, sanitization, per-level export, and per-sink export breakdowns.
- **Network send helpers**: `Network.sendTcp(...)` and `Network.sendSyslogUdp(...)` plus aliases.
- **Formatter template validation**: `Formatter.validateTemplate(...)` and placeholder counting for custom format strings.
- **Metrics level reset helper**: `Metrics.resetLevelMetrics(...)` for targeted level-counter resets.
- **Scheduler dependency validation**: `Scheduler.validateDependencies(...)` to detect missing links and cycles.
- **Filter mode helpers**: `Filter.setMode(...)` and `Filter.isMode(...)` for runtime mode control.
- **Async backpressure tracking**: configurable backpressure threshold, effective batch-size clamping, and default drain timeout helpers.
- **Rules count helpers**: `Rules.hasRules(...)` and `Rules.totalRuleCount(...)` for quick rule-set introspection.

### Fixed

- Fixed formatter theme precedence so sink/formatter custom themes are no longer masked by the default global color config.
- Fixed file-based telemetry span and metrics exporters on Windows by opening append targets with read access before querying length.
- Fixed `LogServer.stop()` shutdown behavior so TCP/UDP worker threads wake before join instead of hanging in network tests.
- Corrected thread pool wait-time stats (ms to ns conversion) to prevent inflated averages.
- Fixed async logging memory leak in the async pipeline.
- Fixed aarch64 build/runtime compatibility issues.
- Replaced comptime-only hex formatting in redaction hashing for Zig 0.16 runtime safety.

### Documentation

- Updated README and API/guide docs for redaction truncate, deterministic sampling, telemetry metric exports, rotation helpers, and network send helpers.
- Added examples for new redaction, sampling, telemetry, rotation, and network helpers.
- Added telemetry metric name prefix/sanitization example and docs.
- Added pipeline controls example covering async, thread pool, metrics, scheduler, rotation, rules, and Prometheus export previews.
- Refreshed telemetry docs to clarify file-based exporter output paths.
- General docs refresh and maintenance updates.

### Tests

- Added formatter theme precedence regression tests.
- Stabilized network send helper test shutdown and callback synchronization.
- Added telemetry metric export format tests.
- Added telemetry metric prefix/sanitization tests.
- Added pipeline builder, metrics export naming/breakdown, async batch/backpressure, and Prometheus label escaping tests.
- Added network send helper tests.
- Added file-based telemetry span export test coverage.
- Added formatter template validation, metrics level reset, scheduler dependency validation, filter mode helper, rules count helper, and async backpressure tests.
